### PR TITLE
Fix Icecast host parsing and the streaming-service manager

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,20 @@
 
 ### Fixes
 
+- An Icecast server entered as `host:port` now works. The port field was appended to whatever was in the server field, so `ice.example.org:8000` became `ice.example.org:8000:8000` and streaming failed with "connection failed: unknown host (os error 11001)". A whole listen URL pasted into the field — scheme, credentials, port and mount and all — is understood too, and its parts are moved into the fields they belong in, so the dialog shows what will actually be dialled.
+
+- Connecting to an Icecast service now checks that the address it was given exists, and reports it on the spot. It used to be pure field validation, so a mistyped server said "Connected" and then failed as a "Streaming problem" the next time Start streaming was pressed. The mount point is not touched by the check.
+
+- The Connect button now acts on the service you have highlighted. It read "Disconnect" whenever any service at all was connected, so pressing it on a service you had just selected disconnected the other one instead of connecting to this one. Pressing Connect on a second service now switches to it.
+
+- Disconnecting now says so, the way connecting always has. The only sign it had worked was a label change on the button already under the cursor, which no screen reader reads out.
+
+- The service list keeps its "(connected)" marker up to date. It was written once, when the dialog opened, so the service you had connected to earlier went on claiming to be connected for as long as the dialog stayed open, and the one you had just connected to never said so.
+
+- Disconnecting from a service while a stream is live now ends the stream in Pubsplash too. The broadcast stopped, but the app stayed on "Streaming" and kept encoding.
+
+- A stream that fails to start now says why in the log. The reason only ever appeared in the modal, which is gone as soon as it is dismissed.
+
 ### Changes
 
 ## 0.1.6

--- a/src/net/icecast.rs
+++ b/src/net/icecast.rs
@@ -44,6 +44,74 @@ pub const WRITE_TIMEOUT: Duration = Duration::from_secs(5);
 /// up the whole teardown.
 const CLOSE_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Splits what someone typed into a "server" field into a host and, when they
+/// included one, a port.
+///
+/// Every other source client takes `host:port` in a single box, so that is what
+/// gets typed into ours — and the port field then appended a second one, making
+/// `gomsen.com:8000:8000`. Nothing resolves that, so it surfaced as
+/// `unknown host (os error 11001)` from **Start streaming**, minutes after the
+/// field that was actually wrong had been left behind. A scheme (`http://`) and
+/// a trailing mount get pasted in for the same reason, out of the listen URL,
+/// and are dropped here too — the mount has its own field.
+///
+/// The returned host is ready to have `:port` appended: an IPv6 literal keeps
+/// its brackets, because that is the form both `TcpStream::connect` and the
+/// `Host` header need.
+pub fn split_host_port(input: &str) -> Result<(String, Option<u16>), String> {
+    let mut rest = input.trim();
+    if let Some((_, after)) = rest.split_once("://") {
+        rest = after;
+    }
+    // Credentials in the authority are never ours to use: the username and
+    // password fields are.
+    if let Some((_, after)) = rest.rsplit_once('@') {
+        rest = after;
+    }
+    // From the first slash on it is a path, i.e. the mount point.
+    if let Some((before, _)) = rest.split_once('/') {
+        rest = before;
+    }
+    let rest = rest.trim();
+    if rest.is_empty() {
+        return Err("Enter the Icecast server.".to_string());
+    }
+    // An IPv6 literal is bracketed and full of colons; only a colon *after* the
+    // closing bracket separates a port.
+    let (host, port_text) = if rest.starts_with('[') {
+        let end = rest
+            .find(']')
+            .ok_or_else(|| format!("{rest:?} is missing its closing ']'."))?;
+        let tail = &rest[end + 1..];
+        if !tail.is_empty() && !tail.starts_with(':') {
+            return Err(format!("{rest:?} is not a server address."));
+        }
+        (&rest[..=end], tail.strip_prefix(':'))
+    } else {
+        match rest.split_once(':') {
+            Some((host, port)) => (host, Some(port)),
+            None => (rest, None),
+        }
+    };
+    let host = host.trim();
+    if host.is_empty() || host == "[]" {
+        return Err("Enter the Icecast server.".to_string());
+    }
+    if host.contains(char::is_whitespace) || (!host.starts_with('[') && host.contains(':')) {
+        return Err(format!("{host:?} is not a server address."));
+    }
+    let port = match port_text.map(str::trim) {
+        None => None,
+        Some(text) => Some(
+            text.parse::<u16>()
+                .ok()
+                .filter(|port| *port != 0)
+                .ok_or_else(|| format!("{text:?} is not a port number."))?,
+        ),
+    };
+    Ok((host.to_string(), port))
+}
+
 #[derive(Debug, Clone)]
 pub struct IcecastTarget {
     /// Host and port, e.g. `live.audiopub.site:8000`.
@@ -344,6 +412,66 @@ mod tests {
         assert_eq!(base64(b"fo"), "Zm8=");
         assert_eq!(base64(b"foo"), "Zm9v");
         assert_eq!(base64(b"source:abc123"), "c291cmNlOmFiYzEyMw==");
+    }
+
+    /// The bug this function exists for: `host:port` in the server field plus a
+    /// port field produced `gomsen.com:8000:8000`, which resolves to nothing.
+    #[test]
+    fn server_field_may_carry_its_own_port() {
+        assert_eq!(
+            split_host_port("gomsen.com:8000").unwrap(),
+            ("gomsen.com".to_string(), Some(8000))
+        );
+        assert_eq!(
+            split_host_port("gomsen.com").unwrap(),
+            ("gomsen.com".to_string(), None)
+        );
+    }
+
+    #[test]
+    fn a_pasted_listen_url_is_reduced_to_its_host() {
+        for pasted in [
+            "http://ice.example.org:8000/live.mp3",
+            "https://ice.example.org:8000/live.mp3",
+            "  http://source:hunter2@ice.example.org:8000/  ",
+            "ice.example.org:8000/live.mp3",
+        ] {
+            assert_eq!(
+                split_host_port(pasted).unwrap(),
+                ("ice.example.org".to_string(), Some(8000)),
+                "{pasted}"
+            );
+        }
+    }
+
+    /// The brackets stay: `TcpStream::connect` and the `Host` header both need
+    /// them once a port is appended.
+    #[test]
+    fn ipv6_literals_keep_their_brackets_and_their_colons() {
+        assert_eq!(
+            split_host_port("[::1]:8000").unwrap(),
+            ("[::1]".to_string(), Some(8000))
+        );
+        assert_eq!(
+            split_host_port("[2001:db8::1]").unwrap(),
+            ("[2001:db8::1]".to_string(), None)
+        );
+    }
+
+    #[test]
+    fn nonsense_is_refused_rather_than_handed_to_the_resolver() {
+        for bad in [
+            "",
+            "   ",
+            "http://",
+            "ice.example.org:",
+            "ice.example.org:0",
+        ] {
+            assert!(split_host_port(bad).is_err(), "{bad:?} should be refused");
+        }
+        assert!(split_host_port("ice.example.org:80000").is_err());
+        assert!(split_host_port("two hosts.example.org").is_err());
+        assert!(split_host_port("[::1:8000").is_err());
     }
 
     #[test]

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -282,12 +282,13 @@ fn direct_icecast_target(
     else {
         return Err("not an Icecast service".to_string());
     };
-    let server = server.trim();
     let mount = normalize_mount(mount);
-    if server.is_empty() {
-        return Err("Enter the Icecast server.".to_string());
-    }
-    if *port == 0 {
+    // The server field is parsed rather than concatenated: a `host:port` typed
+    // into it must not have the port field appended a second time. See
+    // [`icecast::split_host_port`].
+    let (host, typed_port) = icecast::split_host_port(server)?;
+    let port = typed_port.unwrap_or(*port);
+    if port == 0 {
         return Err("Enter a valid Icecast port.".to_string());
     }
     if mount.is_empty() {
@@ -302,12 +303,39 @@ fn direct_icecast_target(
         username.trim().to_string()
     };
     Ok(IcecastTarget {
-        host: format!("{server}:{port}"),
+        host: format!("{host}:{port}"),
         mount,
         username,
         password: password.clone(),
         content_type: content_type.to_string(),
     })
+}
+
+/// Checks that an Icecast host resolves, at Connect time.
+///
+/// A direct Icecast service has nothing to log into, so Connect was pure field
+/// validation and the first thing that ever touched the network was Start
+/// streaming — which is where a mistyped server surfaced, as a "Streaming
+/// problem" modal saying `unknown host`, long after the dialog holding the
+/// field that was wrong had been closed.
+///
+/// A name lookup is the most that can be checked here without harm: a real
+/// handshake would claim the mount, and stock Icecast then holds it for
+/// `<source-timeout>`, so the user's actual Start streaming would answer
+/// `403 Mountpoint in use`.
+async fn resolve_icecast_host(host: &str) -> Result<(), String> {
+    let lookup = tokio::time::timeout(icecast::CONNECT_TIMEOUT, tokio::net::lookup_host(host));
+    let found = match lookup.await {
+        Ok(Ok(mut addresses)) => addresses.next().is_some(),
+        Ok(Err(_)) => false,
+        Err(_) => return Err(format!("looking up the server {host:?} timed out.")),
+    };
+    if !found {
+        return Err(format!(
+            "the server {host:?} could not be found. Check the Icecast server and port."
+        ));
+    }
+    Ok(())
 }
 
 async fn end_active_stream(active: &ActiveStream, connection: Option<&Connection>) {
@@ -402,8 +430,15 @@ async fn net_loop(mut commands: tokio_mpsc::UnboundedReceiver<NetCommand>, event
                             username,
                             password,
                         };
-                        match direct_icecast_target(&armed, "audio/mpeg") {
-                            Ok(_) => {
+                        let checked = match direct_icecast_target(&armed, "audio/mpeg") {
+                            Ok(target) => resolve_icecast_host(&target.host)
+                                .await
+                                .map(|()| target.host),
+                            Err(message) => Err(message),
+                        };
+                        match checked {
+                            Ok(host) => {
+                                log::info!("Icecast service {nickname:?} resolves to {host}");
                                 connection = Some(armed);
                                 let _ = events.send(NetEvent::Connected {
                                     service_id: id,
@@ -411,6 +446,7 @@ async fn net_loop(mut commands: tokio_mpsc::UnboundedReceiver<NetCommand>, event
                                 });
                             }
                             Err(message) => {
+                                log::warn!("Icecast service {nickname:?}: {message}");
                                 let _ = events.send(NetEvent::ConnectFailed { message });
                             }
                         }
@@ -419,7 +455,12 @@ async fn net_loop(mut commands: tokio_mpsc::UnboundedReceiver<NetCommand>, event
             }
             NetCommand::Disconnect => {
                 if let Some(active) = stream.take() {
+                    log::warn!("Disconnecting from a service while a stream is live; ending it");
                     end_active_stream(&active, connection.as_ref()).await;
+                    // Said out loud for the same reason `Connect` says it: the
+                    // UI stayed on "Streaming" otherwise, and the engine kept
+                    // encoding into a channel with nothing left reading it.
+                    let _ = events.send(NetEvent::StreamEnded);
                 }
                 connection = None;
                 let _ = events.send(NetEvent::Disconnected);
@@ -468,6 +509,10 @@ async fn net_loop(mut commands: tokio_mpsc::UnboundedReceiver<NetCommand>, event
                         stream = Some(active);
                     }
                     Err(message) => {
+                        // The only record of a stream that never started: the
+                        // modal this becomes is gone as soon as it is dismissed,
+                        // and the log is what users are asked to send.
+                        log::error!("Starting the stream failed: {message}");
                         let _ = events.send(NetEvent::StreamError { message });
                     }
                 }
@@ -1406,6 +1451,38 @@ mod host_tests {
         assert_eq!(target.username, "dj");
         assert_eq!(target.password.as_str(), "secret");
         assert_eq!(target.content_type, "audio/aac");
+    }
+
+    /// The reported bug: `host:port` typed into the server field had the port
+    /// field appended to it, producing `gomsen.com:8000:8000` and an
+    /// unknown-host failure at Start streaming.
+    #[test]
+    fn a_port_in_the_server_field_is_not_appended_twice() {
+        let conn = Connection::Icecast {
+            server: "gomsen.com:8000".to_string(),
+            port: 8000,
+            mount: "live.mp3".to_string(),
+            username: "source".to_string(),
+            password: Secret::new("secret"),
+        };
+        let target = direct_icecast_target(&conn, "audio/mpeg").unwrap();
+        assert_eq!(target.host, "gomsen.com:8000");
+        assert_eq!(target.mount, "live.mp3");
+    }
+
+    /// The port typed alongside the host wins over the port field, since it is
+    /// the more specific of the two things the user wrote.
+    #[test]
+    fn a_pasted_listen_url_reaches_the_right_host_and_port() {
+        let conn = Connection::Icecast {
+            server: "http://ice.example.org:9000/live".to_string(),
+            port: 8000,
+            mount: "live".to_string(),
+            username: "dj".to_string(),
+            password: Secret::new("secret"),
+        };
+        let target = direct_icecast_target(&conn, "audio/mpeg").unwrap();
+        assert_eq!(target.host, "ice.example.org:9000");
     }
 
     #[test]

--- a/src/ui/connect_dialog.rs
+++ b/src/ui/connect_dialog.rs
@@ -215,6 +215,10 @@ pub fn show(app: &Rc<App>, frame: &Frame) {
         }
     };
 
+    // Refills the service list. `select_id` names the service the selection
+    // should land on and is what marks the call a deliberate edit; `None`
+    // relabels in place and leaves the selection where the user put it, which is
+    // what the connection-state refreshes want - see `super::list`.
     let refresh_services = {
         let app = app.clone();
         move |select_id: Option<&str>| {
@@ -242,17 +246,32 @@ pub fn show(app: &Rc<App>, frame: &Frame) {
                     label
                 })
                 .collect();
-            super::list::fill(&services_list, &labels, NO_SERVICES);
-            if !services.is_empty() {
-                let select_index = services
-                    .iter()
-                    .position(|service| {
-                        Some(service.id.as_str()) == select_id
-                            || Some(service.url.as_str()) == select_id
-                    })
-                    .unwrap_or(0);
-                services_list.set_selection(select_index as u32, true);
+            let synced = super::list::sync(&services_list, &labels, NO_SERVICES);
+            if services.is_empty() {
+                return;
             }
+            if select_id.is_none() && synced == super::list::Synced::Kept {
+                return;
+            }
+            let select_index = services
+                .iter()
+                .position(|service| {
+                    Some(service.id.as_str()) == select_id
+                        || Some(service.url.as_str()) == select_id
+                })
+                .unwrap_or(0);
+            services_list.set_selection(select_index as u32, true);
+        }
+    };
+
+    // The id of the highlighted service, which is what the Connect button acts
+    // on. `None` only for the placeholder row.
+    let selected_service_id = {
+        let app = app.clone();
+        move || -> Option<String> {
+            let config = app.config.borrow();
+            let index = super::list::selection(&services_list, config.connection.sites.len())?;
+            Some(config.connection.sites.get(index)?.id.clone())
         }
     };
 
@@ -314,14 +333,35 @@ pub fn show(app: &Rc<App>, frame: &Frame) {
         }
     };
 
+    // The button acts on the *highlighted* service, so it says which. It used
+    // to read Disconnect whenever any connection existed, which made pressing
+    // it on a service you had just selected disconnect the other one - and
+    // since nothing refreshed the list either, the service you had left behind
+    // went on claiming to be connected.
     let update_connect_label = {
         let app = app.clone();
+        let selected_service_id = selected_service_id.clone();
         move || {
-            // While any connection exists the button reads Disconnect, even
-            // if a different service is highlighted.
-            let connected = app.run.borrow().connected_service.is_some();
-            connect_button.set_label(if connected { "Dis&connect" } else { "&Connect" });
+            let connected = app.run.borrow().connected_service.clone();
+            let disconnects = connected.is_some() && connected == selected_service_id();
+            connect_button.set_label(if disconnects {
+                "Dis&connect"
+            } else {
+                "&Connect"
+            });
         }
+    };
+
+    // Everything the connection state decides, in one call: the pump holds a
+    // handle to this so a result arriving from the network thread updates the
+    // dialog the same way pressing the button does.
+    let sync_connection_ui: std::rc::Rc<dyn Fn()> = {
+        let refresh_services = refresh_services.clone();
+        let update_connect_label = update_connect_label.clone();
+        std::rc::Rc::new(move || {
+            refresh_services(None);
+            update_connect_label();
+        })
     };
 
     let initial_service = {
@@ -338,9 +378,12 @@ pub fn show(app: &Rc<App>, frame: &Frame) {
 
     {
         let load_fields = load_fields.clone();
-        services_list
-            .clone()
-            .on_selection_changed(move |_| load_fields());
+        let update_connect_label = update_connect_label.clone();
+        services_list.clone().on_selection_changed(move |_| {
+            load_fields();
+            // Moving to another service changes what the button will do.
+            update_connect_label();
+        });
     }
 
     {
@@ -374,13 +417,32 @@ pub fn show(app: &Rc<App>, frame: &Frame) {
             }
             service.email = email_input.get_value().trim().to_string();
             service.password = Secret::new(password_input.get_value());
-            service.icecast_server = server_input.get_value().trim().to_string();
-            service.icecast_port = port_input.get_value().trim().parse().unwrap_or(0);
+            // A `host:port`, or a listen URL pasted whole, is unpacked into the
+            // two fields it belongs in - so what is stored, and what the dialog
+            // shows next time, is what will actually be dialled. Anything that
+            // will not parse is kept verbatim for `service_profile_from_site` to
+            // refuse with a message rather than being silently mangled here.
+            let typed_server = server_input.get_value().trim().to_string();
+            let typed_port: u16 = port_input.get_value().trim().parse().unwrap_or(0);
+            let (server, port) = match crate::net::icecast::split_host_port(&typed_server) {
+                Ok((host, embedded)) => (host, embedded.unwrap_or(typed_port)),
+                Err(_) => (typed_server.clone(), typed_port),
+            };
+            service.icecast_server = server.clone();
+            service.icecast_port = port;
             service.icecast_mount = mount_input.get_value().trim().to_string();
             service.icecast_username = username_input.get_value().trim().to_string();
             service.icecast_password = Secret::new(icecast_password_input.get_value());
             let id = service.id.clone();
             drop(config);
+            // After the borrow, not during it: writing to a widget is a call out
+            // into wx, and nothing in this closure may hold `config` across one.
+            if server != typed_server {
+                server_input.set_value(&server);
+            }
+            if port != typed_port {
+                port_input.set_value(&port.to_string());
+            }
             app.save_config();
             Some(id)
         }
@@ -495,15 +557,23 @@ pub fn show(app: &Rc<App>, frame: &Frame) {
 
     {
         let app = app.clone();
-        let update_connect_label = update_connect_label.clone();
+        let selected_service_id = selected_service_id.clone();
         let save_fields = save_fields.clone();
         let dialog_for_connect = dialog;
         connect_button.on_click(move |_| {
-            let connected = app.run.borrow().connected_service.is_some();
-            if connected {
+            let connected = app.run.borrow().connected_service.clone();
+            // Only the connected service's own row disconnects. Pressing this
+            // on any other service connects to that one instead, which the
+            // network thread handles as a switch: it ends whatever stream is
+            // live and replaces the connection.
+            if connected.is_some() && connected == selected_service_id() {
+                // Saved on the way out for the same reason Close saves: what is
+                // typed in these fields is not lost by pressing a button.
+                let _ = save_fields();
                 app.net.send(NetCommand::Disconnect);
-                app.run.borrow_mut().connected_service = None;
-                update_connect_label();
+                // `connected_service`, the button label and the list's
+                // "(connected)" marker are all left to the pump's `Disconnected`
+                // arm, so one place decides what the dialog says.
                 return;
             }
             let Some(id) = save_fields() else { return };
@@ -542,6 +612,7 @@ pub fn show(app: &Rc<App>, frame: &Frame) {
     *app.connect_ui.borrow_mut() = Some(super::ConnectUi {
         dialog,
         connect_button,
+        sync: sync_connection_ui,
     });
     dialog.show_modal();
     *app.connect_ui.borrow_mut() = None;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -660,6 +660,14 @@ pub struct Widgets {
 pub struct ConnectUi {
     pub dialog: Dialog,
     pub connect_button: Button,
+    /// Brings the service list's "(connected)" markers and the Connect button's
+    /// label back in line with `Runtime::connected_service`.
+    ///
+    /// The pump owns both, because the pump is where the connection state
+    /// actually changes. The arms here used to set the button label by hand and
+    /// leave the list alone entirely, so the row of whichever service had been
+    /// connected kept saying so for as long as the dialog stayed open.
+    pub sync: std::rc::Rc<dyn Fn()>,
 }
 
 /// A VST scan in flight: the worker handle plus the progress dialog the pump
@@ -1621,10 +1629,12 @@ pub fn service_profile_from_site(site: &SiteConfig) -> Result<ServiceProfile, St
             })
         }
         StreamingServiceType::Icecast => {
-            if site.icecast_server.trim().is_empty() {
-                return Err("Enter the Icecast server.".to_string());
-            }
-            if site.icecast_port == 0 {
+            // Parsed, not trimmed: a `host:port` or a whole pasted listen URL in
+            // the server field is understood here rather than concatenated with
+            // the port field into something no resolver can answer.
+            let (server, typed_port) = crate::net::icecast::split_host_port(&site.icecast_server)?;
+            let port = typed_port.unwrap_or(site.icecast_port);
+            if port == 0 {
                 return Err("Enter a valid Icecast port.".to_string());
             }
             if site.icecast_mount.trim().trim_start_matches('/').is_empty() {
@@ -1636,8 +1646,8 @@ pub fn service_profile_from_site(site: &SiteConfig) -> Result<ServiceProfile, St
             Ok(ServiceProfile::Icecast {
                 id: site.id.clone(),
                 nickname,
-                server: site.icecast_server.trim().to_string(),
-                port: site.icecast_port,
+                server,
+                port,
                 mount: site.icecast_mount.trim().to_string(),
                 username: site.icecast_username(),
                 password: site.icecast_password.clone(),
@@ -2574,7 +2584,7 @@ fn pump_events(app: &Rc<App>) {
                 // lives for the whole then-branch, which here opens a modal.
                 let connect_ui = app.connect_ui.borrow().clone();
                 if let Some(ui) = connect_ui {
-                    ui.connect_button.set_label("Dis&connect");
+                    (ui.sync)();
                     show_info(
                         &ui.dialog,
                         "Connected",
@@ -2604,13 +2614,32 @@ fn pump_events(app: &Rc<App>) {
             }
             NetEvent::Disconnected => {
                 let mut run = app.run.borrow_mut();
-                run.connected_service = None;
+                let was = run.connected_service.take();
                 run.connecting = false;
                 drop(run);
                 stream_ui_dirty = true;
+                // Read before the sync below rewrites the list, and while the
+                // service is still in config to be named at all.
+                let display_name = was.and_then(|id| {
+                    let config = app.config.borrow();
+                    Some(config.connection.site(&id)?.display_name())
+                });
                 let connect_ui = app.connect_ui.borrow().clone();
                 if let Some(ui) = connect_ui {
-                    ui.connect_button.set_label("&Connect");
+                    (ui.sync)();
+                    // Said out loud, like connecting is. Disconnecting answers a
+                    // button the user just pressed, so it is one of the notices
+                    // that may be a modal - and without it the only sign it
+                    // worked was a label change on the focused button, which no
+                    // screen reader reads out.
+                    show_info(
+                        &ui.dialog,
+                        "Disconnected",
+                        &match display_name {
+                            Some(name) => format!("Disconnected from {name}."),
+                            None => "Disconnected.".to_string(),
+                        },
+                    );
                     ui.connect_button.set_focus();
                 }
             }


### PR DESCRIPTION
Fixes #4.

## The unknown host (os error 11001)

`direct_icecast_target` built the address as `format!("{server}:{port}")`. The reporter's settings held:

```
icecast_server: "gomsen.com:8000"
icecast_port:   8000
```

so the app dialled **`gomsen.com:8000:8000`**. `gomsen.com` resolves fine; `gomsen.com:8000` is a DNS format error, hence `Host desconocido (os error 11001)`. Putting `host:port` in one box is what every other source client takes, so it is the natural thing to type — and the same goes for pasting a listen URL, which is presumably what "I tried everything, http, without http, with mountpoint, without the mountpoint" was.

It surfaced as a **"Streaming problem"** modal rather than from Connect because a direct Icecast service has nothing to log in to: Connect was pure field validation and never touched the network. The first TCP anything happened at Start streaming, long after the dialog holding the wrong field had been closed. Nothing was logged on that path either, which is why the attached log shows no trace of it.

### What changed

- New `icecast::split_host_port`, used by `direct_icecast_target`, `service_profile_from_site` and the dialog's save path. Accepts a bare host, `host:port`, or a whole listen URL (scheme, credentials, port and mount all dropped or moved to the right field); keeps IPv6 brackets, since that is the form `TcpStream::connect` and the `Host` header need; refuses nonsense with a message instead of handing it to the resolver.
- Connect now resolves the host (`resolve_icecast_host`, bounded by `CONNECT_TIMEOUT`) and reports failure on the button. It deliberately does **not** handshake — that would claim the mount, and stock Icecast holds it for `<source-timeout>`, so the user's real Start streaming would then answer `403 Mountpoint in use`.
- A port found in the server field is moved into the port field and written back to the widget, so the dialog shows the address that will actually be dialled. Existing settings files are handled defensively, so nobody has to re-enter anything.

## The manager's Connect button

> when I hit connect on a service in the manager, the button still says connect and lists the previous service as connected

Both halves reproduce from the same two lines:

- The button read `Dis&connect` whenever `connected_service.is_some()` — **globally**, ignoring which service was highlighted. So selecting a second service and pressing the button disconnected the first one and left the label reading "Connect".
- `refresh_services` was only called by add/rename/delete, never on a connection-state change, so the `(connected)` marker was whatever it had been when the dialog opened.

### What changed

- The button acts on the highlighted service: `Dis&connect` only on the connected one, `&Connect` everywhere else. Pressing Connect on a second service switches to it, which `net_loop` already handles (it ends the live stream and replaces the connection).
- `ConnectUi` carries a `sync` handle so the pump relabels the list and the button from the one place the connection state actually changes. The list goes through `list::sync`, so rows are relabelled in place and the selection never moves — no list talking over the user.
- Disconnecting now shows a confirmation, like connecting does. A label change on an already-focused button is inaudible to a screen reader, which is most of why the old behaviour read as "nothing happened".
- Edits typed into the fields are saved when the press is a disconnect, as they already were on Close.

## Two adjacent bugs found in the same path

- `NetCommand::Disconnect` ended a live stream on the network side but never sent `StreamEnded`, so the UI stayed on "Streaming" and the engine kept encoding into a channel nothing was reading. `Connect` has always sent it in the same situation.
- A stream that failed to start logged nothing — the reason existed only in the modal.

## Tests

Six new tests: `split_host_port` over `host:port`, pasted listen URLs, IPv6 literals and malformed input, plus two on `direct_icecast_target` pinning the exact reported case (`gomsen.com:8000` + port 8000 → `gomsen.com:8000`, not `:8000:8000`).

586 pass, `clippy` clean, `fmt` clean on the touched files. Two pre-existing failures on my machine are environment-specific and unrelated — `resolves_a_running_process_to_its_friendly_name` (Spanish Windows calls Explorer "Explorador de Windows") and `voice_enumeration_finds_installed_voices` (no SAPI voices installed here); both fail identically on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
