### PR TITLE
Media Player source: a folder of music that ducks under whoever is talking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,6 +532,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "extended"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2085,9 +2091,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
 dependencies = [
  "lazy_static",
+ "symphonia-bundle-flac",
  "symphonia-bundle-mp3",
+ "symphonia-codec-aac",
+ "symphonia-codec-adpcm",
+ "symphonia-codec-alac",
+ "symphonia-codec-pcm",
+ "symphonia-codec-vorbis",
+ "symphonia-core",
+ "symphonia-format-caf",
+ "symphonia-format-isomp4",
+ "symphonia-format-mkv",
+ "symphonia-format-ogg",
+ "symphonia-format-riff",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-bundle-flac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91565e180aea25d9b80a910c546802526ffd0072d0b8974e3ebe59b686c9976"
+dependencies = [
+ "log",
  "symphonia-core",
  "symphonia-metadata",
+ "symphonia-utils-xiph",
 ]
 
 [[package]]
@@ -2100,6 +2129,58 @@ dependencies = [
  "log",
  "symphonia-core",
  "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-codec-aac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c263845aa86881416849c1729a54c7f55164f8b96111dba59de46849e73a790"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-adpcm"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dddc50e2bbea4cfe027441eece77c46b9f319748605ab8f3443350129ddd07f"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-alac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8413fa754942ac16a73634c9dfd1500ed5c61430956b33728567f667fdd393ab"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-pcm"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e89d716c01541ad3ebe7c91ce4c8d38a7cf266a3f7b2f090b108fb0cb031d95"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-vorbis"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f025837c309cd69ffef572750b4a2257b59552c5399a5e49707cc5b1b85d1c73"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-utils-xiph",
 ]
 
 [[package]]
@@ -2116,6 +2197,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "symphonia-format-caf"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8faf379316b6b6e6bbc274d00e7a592e0d63ff1a7e182ce8ba25e24edd3d096"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-format-isomp4"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "243739585d11f81daf8dac8d9f3d18cc7898f6c09a259675fc364b382c30e0a5"
+dependencies = [
+ "encoding_rs",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-mkv"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "122d786d2c43a49beb6f397551b4a050d8229eaa54c7ddf9ee4b98899b8742d0"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-ogg"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b4955c67c1ed3aa8ae8428d04ca8397fbef6a19b2b051e73b5da8b1435639cb"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-riff"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d7c3df0e7d94efb68401d81906eae73c02b40d5ec1a141962c592d0f11a96f"
+dependencies = [
+ "extended",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
 name = "symphonia-metadata"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2125,6 +2267,16 @@ dependencies = [
  "lazy_static",
  "log",
  "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-utils-xiph"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27c85ab799a338446b68eec77abf42e1a6f1bb490656e121c6e27bfbab9f16"
+dependencies = [
+ "symphonia-core",
+ "symphonia-metadata",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,9 +67,12 @@ thiserror = "2"
 # Edge and Star speak WebSocket, not HTTP. `native-tls` rather than rustls so
 # this shares reqwest's schannel-backed TLS stack instead of linking a second one.
 tokio-tungstenite = { version = "0.30", features = ["native-tls"] }
-# Only Google Translate and Star return compressed audio; every other speech API
-# is asked for PCM or WAV, which `hound` already reads.
-symphonia = { version = "0.5", default-features = false, features = ["mp3"] }
+# Two callers. The speech side is narrow -- only Google Translate and Star return
+# compressed audio, every other API is asked for PCM or WAV, which `hound`
+# already reads -- but the Media Player plays whatever is in the user's music
+# folder, so it needs every container and codec symphonia has. There is no Opus
+# decoder in 0.5, which is why `.opus` is not in `media::SUPPORTED_EXTENSIONS`.
+symphonia = { version = "0.5", default-features = false, features = ["all"] }
 # Edge's Sec-MS-GEC token, Polly's SigV4 signature, and the SHA-256 an update
 # download is verified against.
 sha2 = "0.10"

--- a/README.md
+++ b/README.md
@@ -9,14 +9,16 @@ It is built in Rust with the wxDragon UI toolkit, and designed from the ground u
 - Stream live audio to audiopub.site, a self-hosted Audiopub instance, or a direct Icecast server
 - MP3 encoding with configurable bitrate
 - Scenes: group any number of audio sources and switch between them
-- Source types: microphone, desktop audio, per-application audio, text-to-speech, and sound events
+- Source types: microphone, desktop audio, per-application audio, text-to-speech, sound events, and a media player
 - Applications are picked from a list of what is running by default; just the ones that have actually played sound
 - Sources name themself based on what they're capturing
 - Sources reconnect on their own if their device is unplugged, resets, or is not ready yet when Pubsplash starts. A source that is retrying reads "(reconnecting)" on its mixer strip
 - Audiopub chat: read incoming messages in an accessible list, send outbound messages, and have chat read aloud automatically with text-to-speech (optionally spoken into the stream as well)
 - The chat feed looks after itself: if the connection drops or goes quiet it reconnects on its own, and **Reconnect chat** (`ALT+O`) forces a fresh connection at any time. Neither interrupts your audio
 - Nine speech engines: SAPI 5 and Microsoft Edge need no setup, and Google Translate, OpenAI, ElevenLabs, Azure, AWS Polly, Google Cloud, and a self-hosted Star server are available once you enter their credentials on the Speech tab of Preferences. Keys are encrypted for your Windows account
-- Loop-safe by design: Desktop Audio capture excludes Pubsplash's own audio, so text-to-speech and sound cues can never echo into your stream
+- Loop-safe by design: Desktop Audio capture excludes Pubsplash's own audio, so text-to-speech, sound cues and the media player can never echo into your stream
+- A media player source shuffles a folder of your own music into the stream — MP3, M4A, AAC, FLAC, OGG, WAV and more, subfolders included — with its own volume, mute, monitor and sends like any other source
+- The music gets out of your way on its own: it turns down while you talk, or while chat is being read aloud, and comes back up when you stop, by however much you choose
 - Built-in startup and shutdown sounds, each able to be switched off, plus audio cues for stream events (listener changes, incoming and outgoing messages) that you can send to your listeners or keep to yourself
 - A fully keyboard-accessible mixer with per-source volume and mute, plus an optional per-strip volume boost for sources that are too quiet at 100%
 - Empty lists contain a placeholder item explaining what they're meant to contain, this is a workaround to an NVDA sisue that causes empty controls to not announce their type and speak a message like, "Unknown"
@@ -102,16 +104,17 @@ The **Stream overview** at the top of the Home tab is a list you can arrow throu
 | `CTRL+Tab` / `CTRL+Shift+Tab` | Next / previous parameter (plugin parameter dialog) |
 | `F6` | Inside a plugin's own interface only: move focus back out to the toolbar |
 | `Escape` | Close a plugin's interface window (from its toolbar; inside the plugin's own interface, `Escape` goes to the plugin) |
-| `SHIFT+F10` / `Applications` | Open the context menu for the focused control (mixer volume sliders) |
+| `SHIFT+F10` / `Applications` | Open the context menu for the focused control (mixer volume sliders: volume boost, monitoring, and media player transport) |
 | `ALT+G` | Open the Go to menu (stream page, data directory) |
+| `CTRL+O` | Open a file and play it on your first media player (a default keybinding you can change or remove) |
 
 In the mixer, sliders respond to arrow keys for 1% steps, `Page Up` / `Page Down` for 10% steps, and `Home` / `End` for maximum / minimum volume. `Up`, `Right`, and `Page Up` always raise the volume; `Down`, `Left`, and `Page Down` always lower it.
 
 ### Keybinds
 
-The shortcuts above are fixed, but **Preferences > Keybinds** lets you put your own key on the things you reach for most, so you don't have to tab to the control first. Out of the box `F9` starts and stops streaming and `F10` starts and stops recording; both are ordinary bindings you can change or delete.
+The shortcuts above are fixed, but **Preferences > Keybinds** lets you put your own key on the things you reach for most, so you don't have to tab to the control first. Out of the box `F9` starts and stops streaming and `F10` starts and stops recording, and the first media player you add is given `CTRL+O` for **Open file**; all three are ordinary bindings you can change or delete.
 
-The tab is a list of every action that can be bound, each row reading the action followed by its keys, or *Unassigned*. **Add binding** and **Edit binding** open the same dialog; **Remove binding** (or `Delete` on the list) takes a shortcut away, and **Reset to defaults** puts back just `F9` and `F10`.
+The tab is a list of every action that can be bound, each row reading the action followed by its keys, or *Unassigned*. **Add binding** and **Edit binding** open the same dialog; **Remove binding** (or `Delete` on the list) takes a shortcut away, and **Reset to defaults** puts back just `F9`, `F10`, and `CTRL+O` on your first media player.
 
 You can bind:
 
@@ -119,8 +122,9 @@ You can bind:
 - switching to the next or previous scene — these cycle round, and do nothing at all if you only have one scene — or jumping straight to a scene by name
 - monitoring master, any source, or any bus
 - muting master, any source, or any bus
+- playing or pausing a media player, skipping to its next track, and opening a file to play on it
 
-In the Add binding dialog, choose a category and then an action. Actions that need to know *which* scene, source or bus add a third dropdown right after the action; it disappears again if you pick an action that doesn't need one. Then tab to the **Shortcut** box and simply press the keys you want — they are read back to you. `Escape` or `Delete` clears the box, and `Tab` and `Shift+Tab` still move you on rather than being captured (which is also why they can't be bound). `F1` and `F6` are refused, since they belong to help and pane switching.
+In the Add binding dialog, choose a category and then an action. Actions that need to know *which* scene, source, bus or media player add a third dropdown right after the action; it disappears again if you pick an action that doesn't need one. Then tab to the **Shortcut** box and simply press the keys you want — they are read back to you. `Escape` or `Delete` clears the box, and `Tab` and `Shift+Tab` still move you on rather than being captured (which is also why they can't be bound). `F1` and `F6` are refused, since they belong to help and pane switching.
 
 Tick **Global** to make a shortcut work anywhere in Windows, not only while Pubsplash is in front — handy for muting your microphone from inside a game. A global shortcut has to include `CTRL`, `ALT` or `SHIFT`, or be a function key; a bare letter or digit would be swallowed everywhere you type. Another application that grabs the same combination first still wins.
 
@@ -151,6 +155,44 @@ The picker that opens lists the applications you can capture. Use the controls t
 **Type a name...** enters a program name by hand. This can be used to capture an application that's not running yet. When Pubsplash detects the app, it'll start capturing it automatically.
 
 Applications that run as several processes at once — web browsers, Discord, Spotify, and anything else built on Chromium or Electron — are captured whole; you do not need to know which of their processes makes the sound. If you have two separate copies of the same program open, Pubsplash captures the one that is playing sound, and stays with that copy until you close it.
+
+## The media player
+
+A **Media Player** source plays a folder of your own music into the mix. Add one on the **Scenes and Sources** tab (**Add source**, then pick "Media Player") and its dialog asks for the folder.
+
+Everything in that folder is played, subfolders included, so pointing it at a whole music library works as well as pointing it at one album. Pubsplash plays MP3, M4A, MP4, AAC, FLAC, OGG, WAV, AIFF, CAF, MKA and MP1/MP2 files; anything else in the folder — artwork, playlists, or Opus and WMA files, which Pubsplash cannot decode — is ignored rather than queued and then skipped in silence. The folder is read again every few minutes, so music you add during a session joins in without restarting anything.
+
+**Shuffle the folder** is on by default. Shuffled means every file is played once before any of them repeats; when the folder runs out it is reshuffled, and a new round never starts with the track that just finished. Turn it off to play the folder in filename order instead, over and over.
+
+A media player starts playing as soon as its scene is the live one, and stops when you switch to a scene it is not in — the same rule the microphones follow. Where it has got to is shown in the Sources list: "playing", "paused on", or a note that the folder has nothing playable in it.
+
+### Talking over it
+
+**Turn the music down while other sources are playing** is on by default. With it on, the music drops as soon as any other source in the scene makes a sound, and comes back up about a second after it stops, so you can talk over it — or let chat be read over it — without touching a fader.
+
+**Turned-down level** is how far it drops, as a percentage of this source's own volume slider: 25% means a quarter of whatever the fader is set to, and 0% silences the music completely while anything else is playing. Your microphone, your text-to-speech and your sound events all count as something playing; other media players do not, so two of them never fight each other. A muted microphone, or one pulled down to zero, does not turn the music down either.
+
+**Start turning down at** is how loud something has to get before it counts. It is a level in decibels, from -60 (almost anything) to -10 (only a shout), and it ships at -30 dB: the level of somebody deliberately talking, and far enough above a breath across the microphone, a fan or a knock on the desk that none of those turn your music down. Lower it if a normal sentence does not duck the music; raise it if something in the room does.
+
+**Calibrate to my voice** sets that level for you, and is the easiest way to get it right. Press it and talk normally for five seconds — read a sentence at the volume you actually broadcast at — and Pubsplash listens to the same signal the ducking watches, then puts the level a little way underneath what it heard. It measures whatever is in your live scene right now, through its faders and mutes, so make sure the microphone you are calibrating is in that scene and unmuted. If nothing loud enough to be a voice arrives, it says so and changes nothing.
+
+If your music stays turned down when nobody is talking, the source holding it there is one that is genuinely making noise: a **Desktop Audio** source counts, so a video playing in a background tab will duck the music for as long as it runs.
+
+### Playing, pausing and skipping
+
+The transport is on the media player's mixer strip. Open the strip's volume slider context menu with `SHIFT+F10`, the `Applications` key or a right click, and choose **Play** / **Pause**, **Next track** or **Open file**. All three are also bindable to shortcuts of your own — see [Keybinds](#keybinds) — which is what you want mid-broadcast, since a shortcut works from any tab.
+
+Skipping tells you what it moved to rather than that you pressed it: "Media Player, playing" and then the name of the track now starting.
+
+**Open file** plays one file of your choosing, wherever it is on your computer — it does not have to be in the source's folder, and nothing about it is remembered. It interrupts whatever is playing, exactly as a skip does, and when it finishes the folder carries on with the track it was going to play next. There is a button for it on the media player's mixer strip beside the mute box, and the first media player you add is given `CTRL+O` for it.
+
+Pausing is for this session only: a media player is playing again the next time you start Pubsplash, or the next time you switch back to its scene.
+
+### Hearing it yourself
+
+A media player is an ordinary source in every other respect: it has a volume slider, a mute, bus sends, and its own monitor toggle (`CTRL+M` on its strip, or a keybinding). It plays to the stream by default and is not monitored, so press `CTRL+M` if you want to hear it yourself. What you monitor is exactly what your listeners get, volume and ducking included — when the music ducks for you, it has ducked for them.
+
+If you monitor it through speakers rather than headphones, a microphone source in the same room will pick the music up and send it to the stream a second time, a beat late. That is worth knowing because the more obvious worry — a **Desktop Audio** source capturing the music and doubling it — cannot happen: Desktop Audio deliberately leaves Pubsplash's own sound out, and the media player's audio never leaves Pubsplash except through the mixer. Use headphones and none of it can happen at all.
 
 ## Buses and sends
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,9 +4,37 @@
 
 ### Additions
 
+- **New source type: Media Player.** It plays a folder of music into the mixer, including everything in the folder's subfolders. MP3, M4A, MP4, AAC, FLAC, OGG, WAV, AIFF, CAF, MKA and MP1/MP2 files are played; anything else in the folder is ignored.
+
+- The folder can be played shuffled or in filename order. Shuffled plays every file once before any of them repeats, reshuffles when it runs out, and never starts a new round with the track that just finished.
+
+- The folder is re-read every five minutes and whenever the source's settings are changed, so music added during a session joins in without restarting anything.
+
+- A media player turns itself down while any other source in the scene is making sound, and comes back up about a second after it stops. The level it drops to is set per source as a percentage of that source's own volume slider. Both the ducking and the level are on the source's settings dialog. Other media players do not trigger it, so two of them never fight each other.
+
+- A media player has the same volume slider, mute, monitor toggle and bus sends as every other source. Its monitor carries exactly what the listeners get, ducking included.
+
+- Play/pause, next track and open file are on the mixer strip's context menu (right-click, SHIFT+F10 or the applications key on the strip's volume slider), and can be bound to shortcuts from the new **Media player** category on the Keybinds tab.
+
+- **How loud something has to be before it turns the music down is now yours to set.** A **Start turning down at** slider sits beside the turned-down level on the media player's settings, from -60 dB (almost anything) to -10 dB (only a shout).
+
+- **Calibrate to my voice**, next to that slider, sets it for you: press it, talk normally for five seconds, and Pubsplash measures the very signal the ducking watches — your live scene's sources, through their faders and mutes — and puts the level a little way under what it heard. If nothing loud enough to be a voice arrives, it says so and changes nothing.
+
+- **Open file** on a media player plays one file of your choosing, from anywhere on your computer. It interrupts what is playing exactly as a skip does, and when it ends the folder carries on with the track it was going to play next. There is a button for it on the media player's mixer strip, an item on the strip's context menu, and the first media player you add is given `CTRL+O` for it.
+
+- The Scenes and Sources list shows what each media player is playing, and says so when it is paused, when its folder holds nothing playable, and when no folder has been set yet.
+
 ### Fixes
 
+- **Next track did nothing.** A media player keeps only a quarter of a second of music decoded ahead of the mixer and spends the rest of its time waiting for that to drain, and a skip that arrived during one of those waits was taken off the queue and then discarded. Play and pause were unaffected, which is why it looked like the transport worked.
+
+- **Ducking no longer stays on while nobody is talking.** It measured how loud the other sources were by their loudest single sample in each ten-millisecond block, and a microphone's idle hiss has individual samples well above its actual level — so an open microphone in a silent room held the music down permanently, and ducking looked like it was ignoring the levels entirely. The measurement is now each block's overall level.
+
+- **Ducking no longer fires on a breath or a bump.** The level it triggered at was fixed at -40 dB, which is close enough to a real room's noise floor that wind across the microphone, a fan or a knock on the desk would turn the music down for a second with nothing said. It now starts at -30 dB — the level of somebody deliberately talking — and is a setting, with a Calibrate button that measures your own voice.
+
 ### Changes
+
+- **Next track says which track.** It announced "next track", which the user already knew, and is now the name of the track that is starting.
 
 ## 0.1.6
 

--- a/help.toml
+++ b/help.toml
@@ -224,9 +224,9 @@ message = "While this field has focus, press the key combination you want and it
 
 [[control]]
 id = "dialog.keybind.specifier"
-label = "Binding scene, source or bus choice"
+label = "Binding scene, source, bus or media player choice"
 file = "src/ui/keybinds_ui.rs"
-message = "Which scene, source or bus the action applies to. This appears only for actions that need one, and disappears again when you pick an action that does not. A source shortcut runs against the scene that is live when you press it, so it does nothing while you are in a scene that has no source by that name."
+message = "Which scene, source, bus or media player the action applies to. This appears only for actions that need one, and disappears again when you pick an action that does not. A source shortcut runs against the scene that is live when you press it, so it does nothing while you are in a scene that has no source by that name."
 
 [[control]]
 id = "dialog.loadChain.delete"
@@ -287,6 +287,42 @@ id = "dialog.mastodonTokens.text"
 label = "Template token reference"
 file = "src/ui/mastodon_templates.rs"
 message = "The tokens you can use in a template, one per line, each with what it is replaced with. You can select text here and copy it with CONTROL plus C."
+
+[[control]]
+id = "dialog.mediaPlayerSource.calibrate"
+label = "Calibrate ducking threshold button"
+file = "src/ui/scenes.rs"
+message = "Sets the level above for you. Press this and talk normally for five seconds, at the volume you actually broadcast at, and Pubsplash measures the very signal the ducking watches, then puts the level a little way underneath what it heard. It listens to the sources in your live scene, through their volume sliders and mutes, so the microphone you are calibrating has to be in that scene and unmuted. When it has finished it tells you the level it chose, and the slider above moves to it. If nothing loud enough to be a voice was heard, it says so and nothing is changed. Nothing is saved until you choose OK."
+
+[[control]]
+id = "dialog.mediaPlayerSource.duck"
+label = "Ducking checkbox"
+file = "src/ui/scenes.rs"
+message = "When checked, the music turns itself down whenever any other source in this scene is making sound, and comes back up about a second after it stops. Your microphone and your text-to-speech are both other sources, so this is what lets you talk over the music without touching a fader. Making a sound means a real signal rather than the hiss of an open microphone in a quiet room, so an idle microphone does not hold the music down. Other media players do not count either, so two of them never fight each other. The level it drops to is the next control."
+
+[[control]]
+id = "dialog.mediaPlayerSource.duckLevel"
+label = "Turned-down level slider"
+file = "src/ui/scenes.rs"
+message = "How loud the music is while it is turned down, as a percentage of this source's own volume slider. Twenty-five percent means a quarter of whatever the fader is set to, which leaves the music audible underneath you. Zero silences it completely while anything else is playing. This has no effect unless the checkbox above is checked."
+
+[[control]]
+id = "dialog.mediaPlayerSource.duckThreshold"
+label = "Ducking threshold slider"
+file = "src/ui/scenes.rs"
+message = "How loud another source has to get before the music is turned down, in decibels below full scale. Minus sixty is almost anything, minus ten is only a shout, and the default of minus thirty is the level of somebody deliberately talking, far enough above a breath across the microphone or a knock on the desk that neither turns your music down. Lower it if a normal sentence does not duck the music, raise it if something in the room does, or press the Calibrate button below and let Pubsplash measure your own voice. This has no effect unless the ducking checkbox is checked."
+
+[[control]]
+id = "dialog.mediaPlayerSource.folder"
+label = "Media player folder box"
+file = "src/ui/scenes.rs"
+message = "The folder this source plays, including everything in its subfolders. Type the full path or use the browse button. Pubsplash plays MP3, M4A, AAC, FLAC, OGG, WAV, AIFF and a few others; anything it cannot decode, such as Opus or WMA, is ignored. The folder is read again every few minutes, so music you add during a session joins in without restarting anything. Until this is filled in, the source stays silent."
+
+[[control]]
+id = "dialog.mediaPlayerSource.shuffle"
+label = "Shuffle checkbox"
+file = "src/ui/scenes.rs"
+message = "When checked, the folder is played in a random order, and every file is played once before any of them repeats. It is reshuffled each time it runs out, and never starts a new round with the track that just finished. Unchecked plays the folder in filename order instead, over and over."
 
 [[control]]
 id = "dialog.missingPlugins.apply"
@@ -1043,6 +1079,12 @@ id = "tab.home.mixer.strip.mute"
 label = "Mixer strip mute checkbox"
 file = "src/ui/home.rs"
 message = ""
+
+[[control]]
+id = "tab.home.mixer.strip.openFile"
+label = "Mixer strip open file button"
+file = "src/ui/home.rs"
+message = "Plays one file of your choosing on this media player. The file can be anywhere on your computer and does not have to be in the source's folder. It interrupts whatever is playing, exactly as skipping to the next track does, and when it finishes the folder carries on with the track it was going to play next. Nothing about the file is remembered. This button only appears on a media player's strip."
 
 [[control]]
 id = "tab.home.mixer.strip.volume"

--- a/src/audio/convert.rs
+++ b/src/audio/convert.rs
@@ -116,22 +116,22 @@ pub fn convert_to_stereo(samples: &[f32], source_channels: usize) -> Result<Vec<
     Ok(stereo)
 }
 
-/// Converts a *stream* of little-endian 16-bit PCM into interleaved stereo f32
-/// at [`ENGINE_SAMPLE_RATE`], a chunk at a time.
+/// Resamples a *stream* of interleaved stereo f32 to [`ENGINE_SAMPLE_RATE`], a
+/// piece at a time.
 ///
-/// [`pcm16_to_engine`] cannot just be called per chunk. A frame can straddle a
-/// chunk boundary, and linear interpolation needs the frame *after* the one it
-/// reads from, which may not have arrived yet — converting each chunk on its
-/// own would drop the straddling bytes and clamp the last output frame of every
-/// chunk against a neighbour it cannot see, which is a click per chunk. So this
-/// holds back both the odd trailing bytes and the last complete source frame,
-/// and carries the output position across calls. Feeding a buffer through in
-/// any number of pieces gives the same samples as converting it in one go.
-pub struct Pcm16Stream {
+/// [`resample_stereo`] cannot just be called per piece. Linear interpolation
+/// needs the frame *after* the one it reads from, which may not have arrived
+/// yet, so converting each piece on its own would clamp the last output frame
+/// of every piece against a neighbour it cannot see — a click per piece. This
+/// holds back the last complete source frame instead, and carries the output
+/// position across calls, so feeding a buffer through in any number of pieces
+/// gives the same samples as converting it in one go.
+///
+/// Two callers with the same problem in different clothes: speech APIs deliver
+/// PCM in HTTP chunks ([`Pcm16Stream`], which wraps this), and the media player
+/// decodes a file one packet at a time.
+pub struct StereoStream {
     source_rate: u32,
-    source_channels: usize,
-    /// Bytes from the last chunk that fell short of a whole frame.
-    carry: Vec<u8>,
     /// Source frames from `base` onward, already widened to stereo.
     pending: Vec<f32>,
     /// Index of the source frame sitting in `pending[0]`.
@@ -140,53 +140,37 @@ pub struct Pcm16Stream {
     next_target: u64,
 }
 
-impl Pcm16Stream {
-    pub fn new(source_rate: u32, source_channels: usize) -> Self {
+impl StereoStream {
+    pub fn new(source_rate: u32) -> Self {
         Self {
             source_rate,
-            source_channels,
-            carry: Vec::new(),
             pending: Vec::new(),
             base: 0,
             next_target: 0,
         }
     }
 
-    /// Whether this converter can do anything at all. Nonsense parameters
-    /// yield no samples rather than an error, matching [`pcm16_to_engine`].
+    /// Whether this converter can do anything at all. A zero rate yields no
+    /// samples rather than an error, matching [`pcm16_to_engine`].
     fn usable(&self) -> bool {
-        self.source_rate != 0 && self.source_channels != 0
+        self.source_rate != 0
     }
 
-    /// Samples ready from `bytes` plus whatever was carried over.
-    pub fn push(&mut self, bytes: &[u8]) -> Vec<f32> {
+    /// Feeds already-stereo source frames in and takes whatever is ready.
+    /// `stereo` is interleaved and whole-framed; a trailing half frame is
+    /// dropped rather than carried, since the callers that can produce one
+    /// ([`Pcm16Stream`]) already hold their partial frames back themselves.
+    pub fn push(&mut self, stereo: &[f32]) -> Vec<f32> {
         if !self.usable() {
             return Vec::new();
         }
-        let frame_bytes = self.source_channels * 2;
-        let mut source = std::mem::take(&mut self.carry);
-        source.extend_from_slice(bytes);
-        let whole = source.len() - source.len() % frame_bytes;
-        for frame in source[..whole].chunks_exact(frame_bytes) {
-            let sample = |index: usize| {
-                i16::from_le_bytes([frame[index * 2], frame[index * 2 + 1]]) as f32 / 32768.0
-            };
-            let left = sample(0);
-            self.pending.push(left);
-            self.pending.push(if self.source_channels == 1 {
-                left
-            } else {
-                sample(1)
-            });
-        }
-        self.carry = source[whole..].to_vec();
+        self.pending
+            .extend_from_slice(&stereo[..stereo.len() - stereo.len() % ENGINE_CHANNELS]);
         self.emit(false)
     }
 
-    /// The tail, once the body has ended. A trailing partial frame is dropped,
-    /// as it is in [`pcm16_to_engine`].
+    /// The tail, once the body has ended.
     pub fn finish(&mut self) -> Vec<f32> {
-        self.carry.clear();
         if !self.usable() {
             return Vec::new();
         }
@@ -239,6 +223,71 @@ impl Pcm16Stream {
             self.base = keep_from;
         }
         out
+    }
+}
+
+/// Converts a *stream* of little-endian 16-bit PCM into interleaved stereo f32
+/// at [`ENGINE_SAMPLE_RATE`], a chunk at a time.
+///
+/// [`pcm16_to_engine`] cannot just be called per chunk: a frame can straddle a
+/// chunk boundary, so this holds back the odd trailing bytes, and [`StereoStream`]
+/// underneath holds back the frame the interpolator still needs a partner for.
+pub struct Pcm16Stream {
+    source_channels: usize,
+    /// Bytes from the last chunk that fell short of a whole frame.
+    carry: Vec<u8>,
+    stream: StereoStream,
+}
+
+impl Pcm16Stream {
+    pub fn new(source_rate: u32, source_channels: usize) -> Self {
+        Self {
+            source_channels,
+            carry: Vec::new(),
+            stream: StereoStream::new(source_rate),
+        }
+    }
+
+    /// Whether this converter can do anything at all. Nonsense parameters
+    /// yield no samples rather than an error, matching [`pcm16_to_engine`].
+    fn usable(&self) -> bool {
+        self.stream.usable() && self.source_channels != 0
+    }
+
+    /// Samples ready from `bytes` plus whatever was carried over.
+    pub fn push(&mut self, bytes: &[u8]) -> Vec<f32> {
+        if !self.usable() {
+            return Vec::new();
+        }
+        let frame_bytes = self.source_channels * 2;
+        let mut source = std::mem::take(&mut self.carry);
+        source.extend_from_slice(bytes);
+        let whole = source.len() - source.len() % frame_bytes;
+        let mut stereo = Vec::with_capacity(whole / frame_bytes * ENGINE_CHANNELS);
+        for frame in source[..whole].chunks_exact(frame_bytes) {
+            let sample = |index: usize| {
+                i16::from_le_bytes([frame[index * 2], frame[index * 2 + 1]]) as f32 / 32768.0
+            };
+            let left = sample(0);
+            stereo.push(left);
+            stereo.push(if self.source_channels == 1 {
+                left
+            } else {
+                sample(1)
+            });
+        }
+        self.carry = source[whole..].to_vec();
+        self.stream.push(&stereo)
+    }
+
+    /// The tail, once the body has ended. A trailing partial frame is dropped,
+    /// as it is in [`pcm16_to_engine`].
+    pub fn finish(&mut self) -> Vec<f32> {
+        self.carry.clear();
+        if !self.usable() {
+            return Vec::new();
+        }
+        self.stream.finish()
     }
 }
 
@@ -388,6 +437,43 @@ mod tests {
         let mut out = stream.push(&bytes);
         out.extend(stream.finish());
         assert_eq!(out.len() / ENGINE_CHANNELS, 4);
+    }
+
+    /// The media player's use of the same core: a file decoded packet by packet
+    /// must land where decoding it whole would have.
+    #[test]
+    fn a_piecewise_stereo_resample_matches_a_single_one() {
+        let frames = 700;
+        let source: Vec<f32> = (0..frames * ENGINE_CHANNELS)
+            .map(|n| (n as f32 * 0.013).sin())
+            .collect();
+        for rate in [44_100, 22_050, 96_000] {
+            let whole = resample_stereo(&source, rate, ENGINE_SAMPLE_RATE);
+            for packet in [2, 18, 1152 * ENGINE_CHANNELS] {
+                let mut stream = StereoStream::new(rate);
+                let mut out = Vec::new();
+                for piece in source.chunks(packet) {
+                    out.extend(stream.push(piece));
+                }
+                out.extend(stream.finish());
+                // The one-shot form rounds the frame count; the streaming one
+                // emits every frame whose left neighbour exists, so allow the
+                // pair to differ by a frame at the very end.
+                assert!(
+                    out.len().abs_diff(whole.len()) <= ENGINE_CHANNELS,
+                    "{rate} Hz in {packet}-sample pieces: {} vs {}",
+                    out.len(),
+                    whole.len()
+                );
+                let common = out.len().min(whole.len());
+                for (index, (a, b)) in out[..common].iter().zip(&whole[..common]).enumerate() {
+                    assert!(
+                        (a - b).abs() < 1e-6,
+                        "sample {index} differs at {rate} Hz in {packet}-sample pieces: {a} vs {b}"
+                    );
+                }
+            }
+        }
     }
 
     #[test]

--- a/src/audio/mixer.rs
+++ b/src/audio/mixer.rs
@@ -128,6 +128,214 @@ impl ChannelStrip {
     }
 }
 
+/// How loud another source has to be, post-fader, before it counts as somebody
+/// talking, out of the box. See [`trigger_level`] for why the units matter more
+/// than the number.
+///
+/// It has to sit in the gap between the two things it must tell apart, and that
+/// gap is narrower in a real room than the numbers suggest. A headset
+/// microphone idling in a quiet room measures about -55 dBFS RMS and speech at
+/// an ordinary gain measures -25 to -15 — but a real microphone is not idling in
+/// a quiet room. Breath across the capsule, a fan, a keyboard and a chair all
+/// land tens of dB above that floor, and every one of them re-arms the full
+/// [`DUCK_HOLD_SECONDS`], so a threshold set close to the floor gives music that
+/// is turned down permanently for reasons the user cannot hear. This default is
+/// deliberately well clear of that: it is the level of *deliberate speech*, and
+/// somebody whose voice does not reach it lowers it themselves — with the slider
+/// beside the ducking checkbox, or by pressing Calibrate and talking for five
+/// seconds (see [`calibrated_threshold_db`]).
+pub const DUCK_THRESHOLD_DB_DEFAULT: i32 = -30;
+
+/// The range the threshold slider offers, in dBFS RMS. The bottom is under any
+/// usable noise floor and the top is above ordinary speech, so both ends are
+/// past the point of being useful — which is what a range should be.
+pub const DUCK_THRESHOLD_DB_MIN: i32 = -60;
+pub const DUCK_THRESHOLD_DB_MAX: i32 = -10;
+
+/// How far below the loudest thing calibration heard the threshold is placed.
+///
+/// Calibration measures the *peak* block RMS over its window, which is the
+/// loudest syllable of the loudest word. Speech within one sentence swings well
+/// over 10 dB below that, so the leeway has to be generous enough that ordinary
+/// words still cross the line — and [`DUCK_HOLD_SECONDS`] covers the rest.
+pub const DUCK_CALIBRATION_LEEWAY_DB: f32 = 12.0;
+
+/// The quietest peak calibration will accept as somebody having spoken. Below
+/// this, whatever it heard is more likely to be a room than a voice, and
+/// calibrating to it would produce a threshold that ducks on nothing at all.
+pub const DUCK_CALIBRATION_MIN_SPEECH_DB: f32 = -45.0;
+
+/// How long the music takes to get out of the way. Fast enough that the first
+/// syllable is not lost under it, slow enough not to sound like a gate.
+pub const DUCK_ATTACK_SECONDS: f32 = 0.15;
+
+/// How long it waits, after the last block above the threshold, before starting
+/// to come back. This is what keeps the gaps between words — and between two
+/// sentences of a chat message — from pumping the music up and down.
+pub const DUCK_HOLD_SECONDS: f32 = 1.0;
+
+/// How long the music takes to come back afterwards.
+pub const DUCK_RELEASE_SECONDS: f32 = 0.8;
+
+/// An amplitude (an RMS, here) as dBFS. Silence is [`f32::NEG_INFINITY`] rather
+/// than a very large negative number, so callers have to think about it.
+pub fn amplitude_to_db(amplitude: f32) -> f32 {
+    if amplitude <= 0.0 {
+        return f32::NEG_INFINITY;
+    }
+    20.0 * amplitude.log10()
+}
+
+/// dBFS back to a linear amplitude, which is what [`Ducker`] compares against.
+pub fn db_to_amplitude(db: f32) -> f32 {
+    10f32.powf(db / 20.0)
+}
+
+/// The threshold to set from a calibration run, given the loudest block RMS it
+/// measured while the user was talking.
+///
+/// `None` means the run heard nothing worth calibrating to — a muted or missing
+/// microphone, or one so quiet that the ducker could never work from it — and
+/// the caller must say so rather than writing a threshold nobody can cross.
+pub fn calibrated_threshold_db(peak_rms: f32) -> Option<i32> {
+    let peak_db = amplitude_to_db(peak_rms);
+    if !peak_db.is_finite() || peak_db < DUCK_CALIBRATION_MIN_SPEECH_DB {
+        return None;
+    }
+    Some(
+        (peak_db - DUCK_CALIBRATION_LEEWAY_DB)
+            .round()
+            .clamp(DUCK_THRESHOLD_DB_MIN as f32, DUCK_THRESHOLD_DB_MAX as f32) as i32,
+    )
+}
+
+/// How loud a block is, as the RMS of its samples: what [`Ducker`] compares
+/// against its threshold.
+///
+/// **RMS, not peak, and that is the whole of it.** A peak reading answers the
+/// loudest single sample in ten milliseconds, and noise is spiky: a microphone's
+/// idle noise floor has a crest factor around 10 dB, so a room 20 dB quieter
+/// than speech still touches a peak threshold set below speech, in *every*
+/// block. Each of those blocks re-arms the full [`DUCK_HOLD_SECONDS`], so the
+/// music goes down when the source is opened and never comes back — ducking
+/// that looks, from the outside, like it is ignoring how loud anything is.
+/// An RMS is the block's actual level, and a noise floor measures as one.
+pub fn trigger_level(block: &[f32]) -> f32 {
+    if block.is_empty() {
+        return 0.0;
+    }
+    let sum: f32 = block.iter().map(|s| s * s).sum();
+    (sum / block.len() as f32).sqrt()
+}
+
+/// Turns a media player down while anything else in the scene has signal.
+///
+/// One of these per ducking source, driven once per block from the
+/// [`trigger_level`] of everything else that is playing. The gain it produces is applied *after* the
+/// source's own strip, so it scales whatever the fader is set to rather than
+/// replacing it, and it is applied before every tap — master, sends and the
+/// local monitor alike — so what the broadcaster hears is what the listeners
+/// hear.
+///
+/// Attack, hold and release are all here rather than being a plain gate because
+/// speech is not continuous: the gaps between words fall below any threshold
+/// worth using, and a ducker without a hold answers them by pumping the music
+/// back up between syllables.
+#[derive(Debug, Clone)]
+pub struct Ducker {
+    /// Gain applied while ducked, 0-1. 1 is a ducker that does nothing.
+    ducked_gain: f32,
+    /// The [`trigger_level`] at or above which something counts as talking,
+    /// as a linear amplitude — the user's dB setting resolved once, here,
+    /// rather than a `powf` per block.
+    threshold: f32,
+    /// The gain being applied right now, moving toward its target.
+    current_gain: f32,
+    /// Blocks left to hold the duck after the last one above the threshold.
+    hold_blocks: u32,
+}
+
+impl Ducker {
+    /// `percent` is the level to drop to, as a percentage of the source's own
+    /// fader. Held to 0-100: this attenuates, it never boosts. `threshold_db`
+    /// is how loud everything else has to be before it does — see
+    /// [`DUCK_THRESHOLD_DB_DEFAULT`].
+    pub fn new(percent: u32, threshold_db: i32) -> Self {
+        Self {
+            ducked_gain: percent.min(100) as f32 / 100.0,
+            threshold: db_to_amplitude(clamp_threshold_db(threshold_db) as f32),
+            current_gain: 1.0,
+            hold_blocks: 0,
+        }
+    }
+
+    /// Whether this ducker would behave exactly as one built from `percent` and
+    /// `threshold_db`. Used to carry a duck in progress across a routing update
+    /// rather than snapping the music back to full for a block.
+    pub fn matches(&self, percent: u32, threshold_db: i32) -> bool {
+        let other = Ducker::new(percent, threshold_db);
+        (self.ducked_gain - other.ducked_gain).abs() < f32::EPSILON
+            && (self.threshold - other.threshold).abs() < f32::EPSILON
+    }
+
+    /// Takes this ducker's state over from the one it replaces, so a scene edit
+    /// mid-duck does not jump the music.
+    pub fn adopt(&mut self, previous: &Ducker) {
+        self.current_gain = previous.current_gain;
+        self.hold_blocks = previous.hold_blocks;
+    }
+
+    /// Applies the duck to one block, given the loudest thing anything else in
+    /// the scene is doing.
+    pub fn process(&mut self, block: &mut [f32], trigger: f32) {
+        let target = if trigger >= self.threshold {
+            self.hold_blocks = hold_blocks();
+            self.ducked_gain
+        } else if self.hold_blocks > 0 {
+            self.hold_blocks -= 1;
+            self.ducked_gain
+        } else {
+            1.0
+        };
+        let seconds = if target < self.current_gain {
+            DUCK_ATTACK_SECONDS
+        } else {
+            DUCK_RELEASE_SECONDS
+        };
+        let step = 1.0 / (seconds * SAMPLE_RATE as f32);
+        let mut gain = self.current_gain;
+        for frame in block.chunks_mut(CHANNELS) {
+            if gain < target {
+                gain = (gain + step).min(target);
+            } else {
+                gain = (gain - step).max(target);
+            }
+            if gain != 1.0 {
+                for s in frame {
+                    *s *= gain;
+                }
+            }
+        }
+        self.current_gain = gain;
+    }
+
+    /// The gain being applied right now, for tests.
+    #[cfg(test)]
+    pub fn gain(&self) -> f32 {
+        self.current_gain
+    }
+}
+
+fn hold_blocks() -> u32 {
+    (DUCK_HOLD_SECONDS * SAMPLE_RATE as f32 / BLOCK_FRAMES as f32) as u32
+}
+
+/// Holds a threshold to the range the slider offers. Config is a file users can
+/// edit, and a threshold of 0 dB is a ducker that never fires.
+pub fn clamp_threshold_db(db: i32) -> i32 {
+    db.clamp(DUCK_THRESHOLD_DB_MIN, DUCK_THRESHOLD_DB_MAX)
+}
+
 /// Adds `src` into `dst` (same length), saturating is not needed for f32;
 /// the master stage clamps before conversion to integer PCM.
 pub fn mix_into(dst: &mut [f32], src: &[f32]) {
@@ -269,6 +477,295 @@ mod tests {
             block.iter().all(|&s| (s - 0.5).abs() < 1e-3),
             "gain should cap at MAX_VOLUME / 100 = 5.0"
         );
+    }
+
+    /// A ducker at the shipped threshold, which is what nearly every test here
+    /// is about; the ones that are about the threshold itself spell it out.
+    fn ducker(percent: u32) -> Ducker {
+        Ducker::new(percent, DUCK_THRESHOLD_DB_DEFAULT)
+    }
+
+    /// Runs `blocks` blocks of a steady signal past a ducker and returns the
+    /// last one.
+    fn duck_blocks(ducker: &mut Ducker, blocks: usize, trigger: f32) -> Vec<f32> {
+        let mut block = Vec::new();
+        for _ in 0..blocks {
+            block = vec![1.0f32; BLOCK_SAMPLES];
+            ducker.process(&mut block, trigger);
+        }
+        block
+    }
+
+    #[test]
+    fn a_ducker_with_nothing_talking_over_it_is_silent_about_it() {
+        let mut ducker = ducker(25);
+        let block = duck_blocks(&mut ducker, 10, 0.0);
+        assert!(block.iter().all(|&s| s == 1.0), "untouched at full gain");
+    }
+
+    #[test]
+    fn speech_pulls_the_music_down_to_the_configured_level() {
+        let mut ducker = ducker(25);
+        // Attack is 150 ms; 50 blocks is half a second.
+        duck_blocks(&mut ducker, 50, 0.5);
+        assert!(
+            (ducker.gain() - 0.25).abs() < 1e-3,
+            "settled at 25%: {}",
+            ducker.gain()
+        );
+    }
+
+    /// The attack is a ramp, not a step: the first block after speech starts is
+    /// on its way down, not already there.
+    #[test]
+    fn the_duck_is_a_ramp_rather_than_a_jump() {
+        let mut ducker = ducker(25);
+        let block = duck_blocks(&mut ducker, 1, 0.5);
+        assert!(block[0] > 0.9, "starts from where it was: {}", block[0]);
+        assert!(
+            block[BLOCK_SAMPLES - 1] < 1.0 && block[BLOCK_SAMPLES - 1] > 0.25,
+            "descending, not arrived: {}",
+            block[BLOCK_SAMPLES - 1]
+        );
+    }
+
+    /// The property the hold exists for: a gap between two words must not let
+    /// the music back up.
+    #[test]
+    fn a_gap_between_words_does_not_release_the_duck() {
+        let mut ducker = ducker(25);
+        duck_blocks(&mut ducker, 50, 0.5);
+        // 300 ms of silence — longer than a syllable, shorter than the hold.
+        duck_blocks(&mut ducker, 30, 0.0);
+        assert!(
+            (ducker.gain() - 0.25).abs() < 1e-3,
+            "still ducked through the gap: {}",
+            ducker.gain()
+        );
+    }
+
+    #[test]
+    fn the_music_comes_back_once_the_talking_really_stops() {
+        let mut ducker = ducker(25);
+        duck_blocks(&mut ducker, 50, 0.5);
+        // The hold is a second, the release 800 ms; 300 blocks covers both.
+        duck_blocks(&mut ducker, 300, 0.0);
+        assert!(
+            (ducker.gain() - 1.0).abs() < 1e-3,
+            "back to full: {}",
+            ducker.gain()
+        );
+    }
+
+    /// A source below the threshold is a quiet room, not a person talking.
+    #[test]
+    fn a_signal_under_the_threshold_is_not_somebody_talking() {
+        let mut ducker = ducker(25);
+        let half = db_to_amplitude(DUCK_THRESHOLD_DB_DEFAULT as f32) / 2.0;
+        duck_blocks(&mut ducker, 20, half);
+        assert_eq!(ducker.gain(), 1.0);
+    }
+
+    #[test]
+    fn a_duck_in_progress_survives_a_routing_update() {
+        let mut ducker = ducker(25);
+        duck_blocks(&mut ducker, 5, 0.5);
+        let mid_duck = ducker.gain();
+        assert!(mid_duck < 1.0 && mid_duck > 0.25);
+
+        let mut replacement = Ducker::new(25, DUCK_THRESHOLD_DB_DEFAULT);
+        assert!(replacement.matches(25, DUCK_THRESHOLD_DB_DEFAULT));
+        replacement.adopt(&ducker);
+        assert_eq!(replacement.gain(), mid_duck, "no jump back to full");
+    }
+
+    /// The other half of `matches`: a threshold edit must *not* be carried
+    /// across, or the setting the user just changed would not take effect until
+    /// the next scene switch.
+    #[test]
+    fn a_ducker_does_not_match_one_with_a_different_threshold() {
+        let ducker = ducker(25);
+        assert!(!ducker.matches(25, DUCK_THRESHOLD_DB_DEFAULT - 6));
+        assert!(!ducker.matches(50, DUCK_THRESHOLD_DB_DEFAULT));
+    }
+
+    #[test]
+    fn a_duck_level_above_100_cannot_amplify() {
+        let mut ducker = ducker(400);
+        let block = duck_blocks(&mut ducker, 50, 0.5);
+        assert!(block.iter().all(|&s| s == 1.0), "held at unity");
+    }
+
+    #[test]
+    fn the_trigger_level_is_the_blocks_rms() {
+        // A square wave is the one signal whose RMS is its amplitude.
+        assert!((trigger_level(&[0.5, -0.5, 0.5, -0.5]) - 0.5).abs() < 1e-6);
+        assert_eq!(trigger_level(&[]), 0.0);
+        assert_eq!(trigger_level(&[0.0; 8]), 0.0);
+    }
+
+    /// A block of pseudo-random noise at a given RMS: the shape of a
+    /// microphone's idle noise floor. Deterministic, so the test cannot flake,
+    /// and built by summing four uniform draws so its crest factor is a
+    /// realistic ~10 dB rather than the ~3 dB of a flat distribution — the
+    /// crest factor is the entire point of the tests below.
+    fn noise(rms: f32, seed: &mut u32) -> Vec<f32> {
+        let scale = rms / (2.0 / 3f32.sqrt());
+        (0..BLOCK_SAMPLES)
+            .map(|_| {
+                let mut sum = 0.0;
+                for _ in 0..4 {
+                    *seed = seed.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+                    sum += (*seed >> 8) as f32 / (1u32 << 23) as f32 - 1.0;
+                }
+                sum * scale
+            })
+            .collect()
+    }
+
+    /// Why the trigger is an RMS. A noise floor 20 dB below speech has
+    /// individual samples three times its own level, so a peak reading of it
+    /// lands in the range a threshold set below speech has to occupy.
+    #[test]
+    fn a_noise_floors_peaks_are_not_its_level() {
+        let mut seed = 12_345;
+        let block = noise(0.002, &mut seed);
+        let peak = block.iter().fold(0f32, |max, s| max.max(s.abs()));
+        assert!(
+            peak > 0.005,
+            "a -54 dBFS room peaked at only {peak}; the test's noise is unrealistic"
+        );
+        assert!(
+            trigger_level(&block) < db_to_amplitude(DUCK_THRESHOLD_DB_DEFAULT as f32),
+            "but its level is well under the threshold"
+        );
+    }
+
+    /// An open microphone in a quiet room is not somebody talking, and must
+    /// never hold the music down. Two hundred blocks is two seconds — twice the
+    /// hold — so a single triggered block anywhere in it would still show here.
+    #[test]
+    fn a_microphones_idle_noise_floor_does_not_duck_the_music() {
+        let mut ducker = ducker(30);
+        let mut seed = 12_345;
+        for _ in 0..200 {
+            let mut music = vec![1.0f32; BLOCK_SAMPLES];
+            // -54 dBFS: a headset microphone in a quiet room.
+            ducker.process(&mut music, trigger_level(&noise(0.002, &mut seed)));
+        }
+        assert_eq!(ducker.gain(), 1.0, "the noise floor ducked the music");
+    }
+
+    /// The other half of the same threshold: somebody actually talking over
+    /// that same microphone still ducks it, all the way down.
+    #[test]
+    fn speech_over_the_same_microphone_still_ducks_it() {
+        let mut ducker = ducker(30);
+        let mut seed = 12_345;
+        for _ in 0..100 {
+            let mut music = vec![1.0f32; BLOCK_SAMPLES];
+            // -20 dBFS: ordinary talking at an ordinary microphone gain.
+            ducker.process(&mut music, trigger_level(&noise(0.1, &mut seed)));
+        }
+        assert!(
+            (ducker.gain() - 0.30).abs() < 1e-3,
+            "fully ducked, got {}",
+            ducker.gain()
+        );
+    }
+
+    /// What the default was moved for. A knock on the desk, a breath across the
+    /// capsule or a fan spinning up lands around -38 dBFS — above the -40 the
+    /// threshold used to be fixed at, and so a duck the user cannot account for.
+    #[test]
+    fn a_bump_on_the_microphone_no_longer_ducks_the_music() {
+        let mut ducker = ducker(30);
+        let mut seed = 999;
+        for _ in 0..200 {
+            let mut music = vec![1.0f32; BLOCK_SAMPLES];
+            ducker.process(&mut music, trigger_level(&noise(0.0126, &mut seed)));
+        }
+        assert_eq!(ducker.gain(), 1.0, "a -38 dBFS bump ducked the music");
+    }
+
+    /// And what the slider is for: a quiet or distant voice that the default
+    /// deliberately ignores ducks once the user lowers the threshold to it.
+    #[test]
+    fn a_quiet_voice_ducks_once_the_threshold_is_lowered_to_it() {
+        let mut seed = 4_242;
+        // -35 dBFS: quiet, distant speech.
+        let quiet = |seed: &mut u32| trigger_level(&noise(0.018, seed));
+
+        let mut default = ducker(30);
+        for _ in 0..200 {
+            let mut music = vec![1.0f32; BLOCK_SAMPLES];
+            default.process(&mut music, quiet(&mut seed));
+        }
+        assert_eq!(default.gain(), 1.0, "left alone at the default");
+
+        let mut lowered = Ducker::new(30, -40);
+        for _ in 0..100 {
+            let mut music = vec![1.0f32; BLOCK_SAMPLES];
+            lowered.process(&mut music, quiet(&mut seed));
+        }
+        assert!(
+            (lowered.gain() - 0.30).abs() < 1e-3,
+            "fully ducked at -40 dB, got {}",
+            lowered.gain()
+        );
+    }
+
+    /// Calibration puts the threshold below what it heard, not at it: the peak
+    /// block of a sentence is its loudest syllable, and the rest of the words
+    /// have to keep the duck held.
+    #[test]
+    fn calibration_leaves_room_under_the_voice_it_measured() {
+        // -20 dBFS peak: an ordinary speaking level.
+        let threshold = calibrated_threshold_db(db_to_amplitude(-20.0)).unwrap();
+        assert_eq!(threshold, -32);
+        // A loud voice or a hot microphone gets a higher threshold, and is
+        // still nowhere near the top of the range.
+        assert_eq!(calibrated_threshold_db(db_to_amplitude(-8.0)), Some(-20));
+    }
+
+    /// A calibration run that heard nothing must say so rather than writing a
+    /// threshold. Silence, a muted microphone and a room tone all land here.
+    #[test]
+    fn calibration_refuses_to_guess_from_silence() {
+        assert_eq!(calibrated_threshold_db(0.0), None);
+        assert_eq!(calibrated_threshold_db(db_to_amplitude(-54.0)), None);
+        // Just above the edge of what counts as a voice, it still answers.
+        assert_eq!(
+            calibrated_threshold_db(db_to_amplitude(DUCK_CALIBRATION_MIN_SPEECH_DB + 1.0)),
+            Some(-56)
+        );
+    }
+
+    /// The slider's ends are the only thing a threshold can be, wherever it
+    /// came from — a hand-edited config, or a shout into a hot microphone.
+    #[test]
+    fn a_threshold_is_held_to_the_range_the_slider_offers() {
+        assert_eq!(clamp_threshold_db(0), DUCK_THRESHOLD_DB_MAX);
+        assert_eq!(clamp_threshold_db(-200), DUCK_THRESHOLD_DB_MIN);
+        // Full scale, and past it: a microphone hot enough to clip still
+        // calibrates to a threshold inside the range.
+        assert_eq!(calibrated_threshold_db(1.0), Some(-12));
+        assert_eq!(
+            calibrated_threshold_db(db_to_amplitude(6.0)),
+            Some(DUCK_THRESHOLD_DB_MAX)
+        );
+        // A threshold of 0 dBFS would be a ducker that never fires; clamping is
+        // what keeps `Ducker` from being handed one.
+        let mut never = Ducker::new(30, 0);
+        duck_blocks(&mut never, 50, db_to_amplitude(-10.0));
+        assert!(never.gain() < 1.0, "clamped to the top of the range");
+    }
+
+    #[test]
+    fn decibels_round_trip_through_amplitudes() {
+        assert!((amplitude_to_db(1.0)).abs() < 1e-4);
+        assert!((amplitude_to_db(db_to_amplitude(-30.0)) + 30.0).abs() < 1e-3);
+        assert_eq!(amplitude_to_db(0.0), f32::NEG_INFINITY);
     }
 
     #[test]

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -62,6 +62,26 @@ pub struct SourceSpec {
     /// property of the source. Both taps are taken as one, so a monitored TTS
     /// strip is heard once, not twice.
     pub local: bool,
+    /// How this source gets out of the way while anything else in the scene has
+    /// signal. `None` is a source that never ducks, which is everything except a
+    /// Media Player with ducking on.
+    pub duck: Option<DuckSpec>,
+    /// Whether this source's own signal is what *makes* others duck. False for
+    /// media players, so two of them do not fight each other, and true for
+    /// everything else — a microphone, a chat message being read out, a game.
+    pub duck_trigger: bool,
+}
+
+/// A ducking source's two settings: how far down it goes, and how loud
+/// everything else has to be before it does. Both are the user's, and both are
+/// carried together because [`mixer::Ducker::matches`] has to compare them as a
+/// pair to decide whether a duck in progress survives a routing update.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DuckSpec {
+    /// The level the source drops to, as a percentage of its own fader.
+    pub percent: u32,
+    /// dBFS RMS; see [`mixer::DUCK_THRESHOLD_DB_DEFAULT`].
+    pub threshold_db: i32,
 }
 
 /// A source's send into a bus, addressed by bus index (matching the order
@@ -145,6 +165,15 @@ pub enum EngineCommand {
         path: std::path::PathBuf,
     },
     StopRecording,
+    /// Measure how loud the scene's ducking triggers get over the next
+    /// `seconds`, and answer with [`EngineEvent::DuckTriggerMeasured`].
+    ///
+    /// The measurement is the engine's own [`mixer::trigger_level`] and not a
+    /// separate capture, which is the whole point: a threshold calibrated
+    /// anywhere else would be calibrated against a different signal than the one
+    /// the ducker compares it to. Post-fader like the trigger itself, so a muted
+    /// or pulled-down microphone measures as the silence it is contributing.
+    MeasureDuckTrigger { seconds: f32 },
     Shutdown,
 }
 
@@ -180,6 +209,10 @@ pub enum EngineEvent {
     /// The engine finished applying the FX portion of a `SetRouting` and queued
     /// every replaced chain for reclamation on the UI thread.
     BusesApplied,
+    /// The answer to [`EngineCommand::MeasureDuckTrigger`]: the loudest block
+    /// any ducking trigger produced over the window, as an RMS. Zero is a
+    /// perfectly good answer and means nothing was heard.
+    DuckTriggerMeasured { peak: f32 },
 }
 
 /// Why a recording failed *to start*, as opposed to one that stopped after
@@ -268,6 +301,20 @@ impl ExternalFeeds {
         }
     }
 
+    /// How many samples are already waiting in the named source's ring, or
+    /// `None` when there is no such source.
+    ///
+    /// A one-shot feeder (a cue, an utterance) has no use for this: it pushes
+    /// what it has and is done. A feeder that could run forever does — see
+    /// `media::player`, which uses it to keep only a fraction of a second
+    /// queued, because everything already in the ring is audio that will be
+    /// heard no matter what the user presses next.
+    pub fn queued(&self, name: &str) -> Option<usize> {
+        let map = device::lock_recovering(&self.0, "External feeds");
+        let producer = map.get(name)?;
+        Some(producer.buffer().capacity() - producer.slots())
+    }
+
     /// Feeds a whole buffer in, pacing to the mixer's drain rate, and stops if
     /// the source disappears (a scene switch).
     ///
@@ -302,6 +349,15 @@ impl ExternalFeeds {
     fn clear(&self) {
         self.0.lock().unwrap().clear();
     }
+
+    /// Parks a ring under `name` with no engine behind it, so a test can watch
+    /// what a feeder actually pushes. The engine's own path is `SetRouting`.
+    #[cfg(test)]
+    pub fn park_for_test(&self, name: &str, capacity: usize) -> rtrb::Consumer<f32> {
+        let (producer, consumer) = RingBuffer::new(capacity);
+        self.insert(name.to_string(), producer);
+        consumer
+    }
 }
 
 struct ActiveSource {
@@ -316,6 +372,10 @@ struct ActiveSource {
     monitor: bool,
     /// See [`SourceSpec::local`].
     local: bool,
+    /// Present when this source ducks for the others. See [`mixer::Ducker`].
+    ducker: Option<mixer::Ducker>,
+    /// See [`SourceSpec::duck_trigger`].
+    duck_trigger: bool,
     /// What the capture thread has seen, if this source has one.
     stats: Arc<health::CaptureStats>,
     /// What the mixer has seen of this source's ring since the last report.
@@ -337,6 +397,16 @@ struct ActiveBus {
     /// This block's summed sends, reused across iterations.
     buffer: Vec<f32>,
     monitor: bool,
+}
+
+/// A duck-threshold calibration window in progress. See
+/// [`EngineCommand::MeasureDuckTrigger`].
+struct DuckCalibration {
+    /// Blocks still to be measured. Counted rather than timed so the window is
+    /// the same length of *audio* however the mixer's cadence slips.
+    blocks_left: u32,
+    /// The loudest trigger seen so far.
+    peak: f32,
 }
 
 /// The live monitoring output: the producer half of the ring the render thread
@@ -470,6 +540,12 @@ fn engine_loop(
     // Recording runs on its own encoder so it works with or without streaming.
     let mut rec_encoder: Option<encoder::Mp3Encoder> = None;
     let mut recorder: Option<recorder::RecorderHandle> = None;
+    // A duck-threshold calibration in progress; see `EngineCommand::
+    // MeasureDuckTrigger`. Its presence also keeps the loop off the idle park
+    // below, or a scene with nothing but a media player in it would park with
+    // the measurement still owing and answer only when the user next did
+    // something.
+    let mut calibration: Option<DuckCalibration> = None;
 
     let block_period = Duration::from_millis(10);
     let mut next_tick = Instant::now() + block_period;
@@ -503,7 +579,8 @@ fn engine_loop(
             && rec_encoder.is_none()
             && recorder.is_none()
             && monitor_out.is_none()
-            && !master_monitor;
+            && !master_monitor
+            && calibration.is_none();
         if idle && parked_command.is_none() {
             match commands.recv() {
                 Ok(command) => parked_command = Some(command),
@@ -547,6 +624,14 @@ fn engine_loop(
                     // waiting to hear that its retired plugins are unreferenced.
                     let touched_fx = new_buses.is_some() || new_master_chain.is_some();
                     if let Some(specs) = new_sources {
+                        // A routing update arrives for every scene edit, and a
+                        // media player mid-duck must not be snapped back to full
+                        // by one. Duckers are carried across by source name (the
+                        // identity key), and only when the level still agrees.
+                        let previous_duckers: HashMap<String, mixer::Ducker> = sources
+                            .iter()
+                            .filter_map(|s| Some((s.name.clone(), s.ducker.clone()?)))
+                            .collect();
                         stop_sources(&mut sources, last_health.elapsed());
                         // The replacement sources deserve a full window before
                         // their first line, and their rings start empty.
@@ -581,6 +666,16 @@ fn engine_loop(
                                     feeds.insert(spec.name.clone(), producer);
                                 }
                             }
+                            let ducker = spec.duck.map(|duck| {
+                                let mut ducker =
+                                    mixer::Ducker::new(duck.percent, duck.threshold_db);
+                                if let Some(previous) = previous_duckers.get(&spec.name)
+                                    && previous.matches(duck.percent, duck.threshold_db)
+                                {
+                                    ducker.adopt(previous);
+                                }
+                                ducker
+                            });
                             sources.push(ActiveSource {
                                 name: spec.name,
                                 strip: ChannelStrip::new(spec.volume, spec.muted),
@@ -591,6 +686,8 @@ fn engine_loop(
                                 sends: active_sends(spec.sends),
                                 monitor: spec.monitor,
                                 local: spec.local,
+                                ducker,
+                                duck_trigger: spec.duck_trigger,
                                 stats,
                                 window: health::Window::default(),
                                 baseline: health::Counters::default(),
@@ -734,6 +831,15 @@ fn engine_loop(
                 Ok(EngineCommand::StopRecording) => {
                     finalize_recording(&mut rec_encoder, &mut recorder);
                 }
+                Ok(EngineCommand::MeasureDuckTrigger { seconds }) => {
+                    // A second press replaces the first rather than queueing, so
+                    // the user cannot be left waiting out somebody else's window.
+                    calibration = Some(DuckCalibration {
+                        blocks_left: (seconds.max(0.0) * mixer::SAMPLE_RATE as f32
+                            / mixer::BLOCK_FRAMES as f32) as u32,
+                        peak: 0.0,
+                    });
+                }
                 Ok(EngineCommand::Shutdown) => {
                     finalize_recording(&mut rec_encoder, &mut recorder);
                     stop_sources(&mut sources, last_health.elapsed());
@@ -800,7 +906,7 @@ fn engine_loop(
             _ => {}
         }
 
-        mix_one_block(
+        let trigger = mix_one_block(
             &mut sources,
             &mut buses,
             &mut master_chain,
@@ -811,6 +917,17 @@ fn engine_loop(
             master_monitor,
         );
         crate::vst::host2::advance_transport(mixer::BLOCK_FRAMES as u64);
+
+        // A calibration window, if one is open. The peak of the same number the
+        // ducker tests against, so the threshold it produces means what it says.
+        if let Some(run) = &mut calibration {
+            run.peak = run.peak.max(trigger);
+            run.blocks_left = run.blocks_left.saturating_sub(1);
+            if run.blocks_left == 0 {
+                events.send(EngineEvent::DuckTriggerMeasured { peak: run.peak });
+                calibration = None;
+            }
+        }
 
         if let Some(out) = &mut monitor_out {
             // A short ring means the render thread is behind; writing what
@@ -925,6 +1042,15 @@ fn engine_loop(
 /// **post-fader and post-mute**, so what a monitored strip sounds like is
 /// exactly what it contributes: muting it silences the monitor too, and its
 /// volume slider moves the monitor level.
+///
+/// The two passes over the sources are what ducking needs and the only reason
+/// they are two: a media player's gain for this block depends on how loud
+/// *everything else* is in the same block, so every strip has to be pulled and
+/// faded before any of them can be routed. The duck is applied between the
+/// passes, which puts it ahead of every tap — master, sends and monitor alike —
+/// so the broadcaster hears the music duck exactly as the listeners do.
+///
+/// Returns that trigger level, which is what a threshold calibration measures.
 #[allow(clippy::too_many_arguments)]
 fn mix_one_block(
     sources: &mut [ActiveSource],
@@ -935,12 +1061,17 @@ fn mix_one_block(
     monitor_block: &mut [f32],
     send_scratch: &mut [f32],
     master_monitor: bool,
-) {
+) -> f32 {
     mix_block.fill(0.0);
     monitor_block.fill(0.0);
     for bus in buses.iter_mut() {
         bus.buffer.fill(0.0);
     }
+    // The loudest post-fader block among the sources that make others duck.
+    // Post-fader, so a muted microphone or one pulled to zero stops ducking the
+    // music — the trigger is what the source is contributing, not what its
+    // device happens to be hearing.
+    let mut trigger_level = 0.0f32;
     for source in sources.iter_mut() {
         // Ring occupancy is read here, before the pull, because this is the only
         // place it can be: the level *after* a pull is always near zero, and it
@@ -956,6 +1087,14 @@ fn mix_one_block(
             source.window.starved_blocks += 1;
         }
         source.strip.process(&mut source.scratch);
+        if source.duck_trigger {
+            trigger_level = trigger_level.max(mixer::trigger_level(&source.scratch));
+        }
+    }
+    for source in sources.iter_mut() {
+        if let Some(ducker) = &mut source.ducker {
+            ducker.process(&mut source.scratch, trigger_level);
+        }
         // One tap for both reasons a strip can be heard locally. The implicit
         // one is dropped when the strip is already arriving through the master
         // monitor below, so a broadcaster monitoring master does not hear their
@@ -991,6 +1130,7 @@ fn mix_one_block(
     if master_monitor {
         mixer::mix_into(monitor_block, mix_block);
     }
+    trigger_level
 }
 
 /// Hands every live `FxChain` back for the UI thread to drop.
@@ -1107,6 +1247,8 @@ mod routing_tests {
             sends: active_sends(sends),
             monitor: false,
             local: false,
+            ducker: None,
+            duck_trigger: true,
             stats: Arc::new(health::CaptureStats::new()),
             window: health::Window::default(),
             baseline: health::Counters::default(),
@@ -1308,6 +1450,135 @@ mod routing_tests {
         let mut buses = Vec::new();
         let (_, monitor) = run_block_monitoring(&mut sources, &mut buses, true);
         assert!((monitor[0] - 1.0).abs() < 1e-6, "got {}", monitor[0]);
+    }
+
+    /// How many blocks of signal the ducking tests' rings hold. A duck ramp is
+    /// measured in hundreds of milliseconds and the hold is a second, so these
+    /// tests run through seconds of audio, and both sources have to keep playing
+    /// for all of it — a ring that runs dry reads as somebody stopping talking.
+    const STEADY_BLOCKS: usize = 400;
+
+    /// A source that plays a constant value for [`STEADY_BLOCKS`] blocks.
+    fn steady_source(value: f32, muted: bool) -> ActiveSource {
+        let (mut producer, consumer) = RingBuffer::new(BLOCK_SAMPLES * STEADY_BLOCKS);
+        for _ in 0..BLOCK_SAMPLES * STEADY_BLOCKS {
+            producer.push(value).unwrap();
+        }
+        let mut source = test_source(value, 100, muted, true, vec![]);
+        source.consumer = consumer;
+        source
+    }
+
+    /// A monitored media player at full volume, plus whatever is playing over
+    /// it. The music is first and is the only monitored strip, so `monitor[0]`
+    /// is the music on its own.
+    fn ducking_pair(duck_percent: u32, over: ActiveSource) -> Vec<ActiveSource> {
+        let mut music = steady_source(1.0, false);
+        music.ducker = Some(mixer::Ducker::new(
+            duck_percent,
+            mixer::DUCK_THRESHOLD_DB_DEFAULT,
+        ));
+        music.duck_trigger = false;
+        music.monitor = true;
+        vec![music, over]
+    }
+
+    /// Runs `blocks` blocks and returns the last `(master, monitor)` pair.
+    fn run_blocks(sources: &mut [ActiveSource], blocks: usize) -> (Vec<f32>, Vec<f32>) {
+        let mut buses = Vec::new();
+        let mut out = (Vec::new(), Vec::new());
+        for _ in 0..blocks {
+            out = run_block_monitoring(sources, &mut buses, false);
+        }
+        out
+    }
+
+    /// The point of the whole feature: somebody talking turns the music down.
+    #[test]
+    fn a_talking_source_ducks_the_media_player() {
+        let mut sources = ducking_pair(25, steady_source(0.5, false));
+        // Half a second, past the 150 ms attack.
+        let (mix, _) = run_blocks(&mut sources, 50);
+        // Master carries the ducked music plus the talking itself.
+        assert!((mix[0] - 0.75).abs() < 1e-3, "music at 25%: {}", mix[0]);
+    }
+
+    /// What the broadcaster hears is what the listeners hear: the monitor tap is
+    /// after the duck, not before it.
+    #[test]
+    fn the_monitor_hears_the_music_ducked() {
+        let mut sources = ducking_pair(25, steady_source(0.5, false));
+        let (_, monitor) = run_blocks(&mut sources, 50);
+        assert!(
+            (monitor[0] - 0.25).abs() < 1e-3,
+            "monitored music is the ducked signal: {}",
+            monitor[0]
+        );
+    }
+
+    /// A media player is not a trigger, so two of them never duck each other.
+    #[test]
+    fn one_media_player_does_not_duck_another() {
+        let mut other = steady_source(1.0, false);
+        other.duck_trigger = false;
+        let mut sources = ducking_pair(25, other);
+        let (_, monitor) = run_blocks(&mut sources, 50);
+        assert!((monitor[0] - 1.0).abs() < 1e-6, "full level: {}", monitor[0]);
+    }
+
+    /// The trigger is post-fader, so muting the microphone stops it ducking.
+    #[test]
+    fn a_muted_talker_does_not_duck_anything() {
+        let mut sources = ducking_pair(25, steady_source(0.5, true));
+        let (_, monitor) = run_blocks(&mut sources, 50);
+        assert!((monitor[0] - 1.0).abs() < 1e-6, "full level: {}", monitor[0]);
+    }
+
+    /// One block, returning the trigger level `mix_one_block` reports — the
+    /// number a duck-threshold calibration takes the peak of.
+    fn run_block_trigger(sources: &mut [ActiveSource]) -> f32 {
+        let mut buses = Vec::new();
+        let mut master_chain = FxChain::empty();
+        let mut master = ChannelStrip::new(100, false);
+        let mut mix_block = vec![0f32; BLOCK_SAMPLES];
+        let mut monitor_block = vec![0f32; BLOCK_SAMPLES];
+        let mut send_scratch = vec![0f32; BLOCK_SAMPLES];
+        mix_one_block(
+            sources,
+            &mut buses,
+            &mut master_chain,
+            &mut master,
+            &mut mix_block,
+            &mut monitor_block,
+            &mut send_scratch,
+            false,
+        )
+    }
+
+    /// A calibration measures the number the ducker itself tests, which is why
+    /// the mixer reports it rather than the UI measuring anything of its own.
+    #[test]
+    fn the_measured_trigger_is_the_talker_and_never_the_music() {
+        let mut sources = ducking_pair(25, steady_source(0.5, false));
+        let trigger = run_block_trigger(&mut sources);
+        assert!(
+            (trigger - 0.5).abs() < 1e-3,
+            "the talker's own level, not the louder music: {trigger}"
+        );
+
+        // A muted microphone contributes silence, so a calibration run over one
+        // measures silence and has to say so rather than write a threshold.
+        let mut muted = ducking_pair(25, steady_source(0.5, true));
+        assert_eq!(run_block_trigger(&mut muted), 0.0);
+    }
+
+    /// Ducking turned off is a media player that mixes like any other source.
+    #[test]
+    fn a_media_player_with_ducking_off_is_left_alone() {
+        let mut sources = ducking_pair(25, steady_source(0.5, false));
+        sources[0].ducker = None;
+        let (_, monitor) = run_blocks(&mut sources, 50);
+        assert!((monitor[0] - 1.0).abs() < 1e-6, "full level: {}", monitor[0]);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,8 @@ impl Config {
     /// blank names (first occurrence wins), drops sends that reference a bus
     /// that no longer exists, and holds every un-boosted strip at 100 so a
     /// hand-edited (or downgraded) file can't leave a strip silently amplified.
+    /// A media player's duck level is held to its own range for the same
+    /// reason — above 100 it would amplify rather than attenuate.
     pub fn fix_up_routing(&mut self) {
         let mut seen = std::collections::HashSet::new();
         self.buses
@@ -44,6 +46,9 @@ impl Config {
             for source in &mut scene.sources {
                 source.sends.retain(|s| names.contains(&s.bus));
                 source.volume = clamp_volume(source.volume, source.boost);
+                if let SourceKindConfig::MediaPlayer(media) = &mut source.kind {
+                    media.fix_up();
+                }
             }
         }
         for bus in &mut self.buses.buses {
@@ -716,6 +721,7 @@ pub enum SourceKindConfig {
     },
     Tts(TtsSourceConfig),
     SoundEvents(SoundEventsSourceConfig),
+    MediaPlayer(MediaPlayerSourceConfig),
 }
 
 impl SourceKindConfig {
@@ -726,6 +732,7 @@ impl SourceKindConfig {
             SourceKindConfig::Application { .. } => "Application",
             SourceKindConfig::Tts(_) => "Text-to-Speech",
             SourceKindConfig::SoundEvents(_) => "Sound Events",
+            SourceKindConfig::MediaPlayer(_) => "Media Player",
         }
     }
 }
@@ -1748,5 +1755,49 @@ impl Default for SoundEventsSourceConfig {
             outgoing_chat: true,
             output_to_stream: true,
         }
+    }
+}
+
+/// Settings for one Media Player source: a folder of music, and how it gets out
+/// of the way of whoever is talking.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct MediaPlayerSourceConfig {
+    /// The folder played, including its subfolders. Empty means unconfigured,
+    /// which is a source that stays silent rather than an error.
+    pub folder: String,
+    /// Play the folder in a random order, reshuffled each time it runs out.
+    /// Off plays it in filename order.
+    pub shuffle: bool,
+    /// Turn the music down while any other source in the scene has signal.
+    pub duck: bool,
+    /// The level the music drops to while ducked, as a percentage of its own
+    /// fader — 30 means "a third of whatever the strip is set to". Held to
+    /// 0-100 by [`MediaPlayerSourceConfig::fix_up`]: this is an attenuation, and
+    /// a value above 100 would turn ducking into a boost.
+    pub duck_percent: u32,
+    /// How loud everything else has to be before the music gets out of the way,
+    /// in dBFS RMS. Held to the range the slider offers — see
+    /// [`crate::audio::mixer::DUCK_THRESHOLD_DB_DEFAULT`], which is also what a
+    /// settings file written before this existed loads as.
+    pub duck_threshold_db: i32,
+}
+
+impl Default for MediaPlayerSourceConfig {
+    fn default() -> Self {
+        Self {
+            folder: String::new(),
+            shuffle: true,
+            duck: true,
+            duck_percent: 25,
+            duck_threshold_db: crate::audio::mixer::DUCK_THRESHOLD_DB_DEFAULT,
+        }
+    }
+}
+
+impl MediaPlayerSourceConfig {
+    pub fn fix_up(&mut self) {
+        self.duck_percent = self.duck_percent.min(100);
+        self.duck_threshold_db = crate::audio::mixer::clamp_threshold_db(self.duck_threshold_db);
     }
 }

--- a/src/keybind.rs
+++ b/src/keybind.rs
@@ -183,6 +183,13 @@ pub enum BindAction {
     ToggleMuteMaster,
     ToggleMuteSource { source: String },
     ToggleMuteBus { bus: String },
+    /// Play or pause one Media Player source.
+    ToggleMediaPlayback { source: String },
+    /// Abandon the track a Media Player source is on and start the next one.
+    NextTrack { source: String },
+    /// Pick a file and play it on a Media Player source, in place of whatever it
+    /// is on now.
+    OpenTrack { source: String },
 }
 
 /// Which extra dropdown the Add-binding dialog must show for an action.
@@ -192,6 +199,10 @@ pub enum Specifier {
     Scene,
     Source,
     Bus,
+    /// Media Player sources only. A separate list from [`Specifier::Source`]
+    /// because binding "next track" to a microphone is not a thing a user could
+    /// have meant, and the dropdown is where that is worth saying.
+    MediaSource,
 }
 
 impl Specifier {
@@ -202,6 +213,7 @@ impl Specifier {
             Specifier::Scene => "Scene",
             Specifier::Source => "Source",
             Specifier::Bus => "Bus",
+            Specifier::MediaSource => "Media player",
         }
     }
 }
@@ -213,14 +225,16 @@ pub enum Category {
     Scenes,
     Monitoring,
     Muting,
+    MediaPlayer,
 }
 
 impl Category {
-    pub const ALL: [Category; 4] = [
+    pub const ALL: [Category; 5] = [
         Category::Streaming,
         Category::Scenes,
         Category::Monitoring,
         Category::Muting,
+        Category::MediaPlayer,
     ];
 
     pub fn label(&self) -> &'static str {
@@ -229,6 +243,7 @@ impl Category {
             Category::Scenes => "Scenes",
             Category::Monitoring => "Monitoring",
             Category::Muting => "Muting",
+            Category::MediaPlayer => "Media player",
         }
     }
 
@@ -259,6 +274,17 @@ impl Category {
                 },
                 BindAction::ToggleMuteBus { bus: String::new() },
             ],
+            Category::MediaPlayer => vec![
+                BindAction::ToggleMediaPlayback {
+                    source: String::new(),
+                },
+                BindAction::NextTrack {
+                    source: String::new(),
+                },
+                BindAction::OpenTrack {
+                    source: String::new(),
+                },
+            ],
         }
     }
 }
@@ -276,6 +302,9 @@ impl BindAction {
             BindAction::ToggleMuteMaster
             | BindAction::ToggleMuteSource { .. }
             | BindAction::ToggleMuteBus { .. } => Category::Muting,
+            BindAction::ToggleMediaPlayback { .. }
+            | BindAction::NextTrack { .. }
+            | BindAction::OpenTrack { .. } => Category::MediaPlayer,
         }
     }
 
@@ -288,6 +317,9 @@ impl BindAction {
             BindAction::ToggleMonitorBus { .. } | BindAction::ToggleMuteBus { .. } => {
                 Specifier::Bus
             }
+            BindAction::ToggleMediaPlayback { .. }
+            | BindAction::NextTrack { .. }
+            | BindAction::OpenTrack { .. } => Specifier::MediaSource,
             _ => Specifier::None,
         }
     }
@@ -297,7 +329,10 @@ impl BindAction {
         match self {
             BindAction::SwitchScene { scene } => Some(scene),
             BindAction::ToggleMonitorSource { source }
-            | BindAction::ToggleMuteSource { source } => Some(source),
+            | BindAction::ToggleMuteSource { source }
+            | BindAction::ToggleMediaPlayback { source }
+            | BindAction::NextTrack { source }
+            | BindAction::OpenTrack { source } => Some(source),
             BindAction::ToggleMonitorBus { bus } | BindAction::ToggleMuteBus { bus } => Some(bus),
             _ => None,
         }
@@ -315,6 +350,11 @@ impl BindAction {
             BindAction::ToggleMuteSource { .. } => BindAction::ToggleMuteSource { source: name },
             BindAction::ToggleMonitorBus { .. } => BindAction::ToggleMonitorBus { bus: name },
             BindAction::ToggleMuteBus { .. } => BindAction::ToggleMuteBus { bus: name },
+            BindAction::ToggleMediaPlayback { .. } => {
+                BindAction::ToggleMediaPlayback { source: name }
+            }
+            BindAction::NextTrack { .. } => BindAction::NextTrack { source: name },
+            BindAction::OpenTrack { .. } => BindAction::OpenTrack { source: name },
             other => other.clone(),
         }
     }
@@ -334,6 +374,9 @@ impl BindAction {
             BindAction::ToggleMuteMaster => "Mute or unmute master",
             BindAction::ToggleMuteSource { .. } => "Mute or unmute a source",
             BindAction::ToggleMuteBus { .. } => "Mute or unmute a bus",
+            BindAction::ToggleMediaPlayback { .. } => "Play or pause a media player",
+            BindAction::NextTrack { .. } => "Skip to the next track",
+            BindAction::OpenTrack { .. } => "Open a file and play it",
         }
     }
 
@@ -345,6 +388,9 @@ impl BindAction {
             BindAction::ToggleMonitorBus { bus } => format!("Monitor the bus {bus}"),
             BindAction::ToggleMuteSource { source } => format!("Mute or unmute {source}"),
             BindAction::ToggleMuteBus { bus } => format!("Mute or unmute the bus {bus}"),
+            BindAction::ToggleMediaPlayback { source } => format!("Play or pause {source}"),
+            BindAction::NextTrack { source } => format!("Skip to the next track on {source}"),
+            BindAction::OpenTrack { source } => format!("Open a file and play it on {source}"),
             other => other.template_label().to_string(),
         }
     }
@@ -360,6 +406,8 @@ pub struct Targets {
     pub scenes: Vec<String>,
     pub sources: Vec<String>,
     pub buses: Vec<String>,
+    /// The subset of `sources` that are Media Players.
+    pub media_sources: Vec<String>,
 }
 
 impl Targets {
@@ -373,10 +421,16 @@ impl Targets {
     /// lives in some other scene bindable at all.
     pub fn from_config(config: &Config) -> Self {
         let mut sources: Vec<String> = Vec::new();
+        let mut media_sources: Vec<String> = Vec::new();
         for scene in &config.scenes.scenes {
             for source in &scene.sources {
                 if !sources.iter().any(|s| s == &source.name) {
                     sources.push(source.name.clone());
+                }
+                if matches!(source.kind, crate::config::SourceKindConfig::MediaPlayer(_))
+                    && !media_sources.iter().any(|s| s == &source.name)
+                {
+                    media_sources.push(source.name.clone());
                 }
             }
         }
@@ -389,6 +443,7 @@ impl Targets {
                 .collect(),
             sources,
             buses: config.buses.buses.iter().map(|b| b.name.clone()).collect(),
+            media_sources,
         }
     }
 
@@ -398,6 +453,7 @@ impl Targets {
             Specifier::Scene => &self.scenes,
             Specifier::Source => &self.sources,
             Specifier::Bus => &self.buses,
+            Specifier::MediaSource => &self.media_sources,
         }
     }
 }
@@ -478,6 +534,38 @@ pub const VK_F1: u32 = 0x70;
 pub const VK_F6: u32 = 0x75;
 pub const VK_F9: u32 = 0x78;
 pub const VK_F10: u32 = 0x79;
+pub const VK_O: u32 = b'O' as u32;
+
+/// The chord a new Media Player source is given for Open file, if it is free.
+///
+/// Not in [`KeybindsConfig::default`] with the other two, because it cannot be:
+/// the action names a source, and no source exists when the defaults are built.
+/// So it is seeded when a Media Player is added instead — which also means every
+/// existing settings file gets it on the next one added, rather than never.
+pub const DEFAULT_OPEN_TRACK: Chord = Chord {
+    vk: VK_O,
+    ctrl: true,
+    alt: false,
+    shift: false,
+};
+
+impl KeybindsConfig {
+    /// Gives `source` the default Open-file chord, unless something already
+    /// holds that chord — including an earlier media player, since two sources
+    /// cannot share one key and the first one to be added keeps it.
+    ///
+    /// Returns whether anything was added, so the caller knows to save.
+    pub fn seed_media_defaults(&mut self, source: &str) -> bool {
+        let action = BindAction::OpenTrack {
+            source: source.to_string(),
+        };
+        if self.find(&action).is_some() || self.conflict(DEFAULT_OPEN_TRACK, None).is_some() {
+            return false;
+        }
+        self.set(action, DEFAULT_OPEN_TRACK, false);
+        true
+    }
+}
 
 impl KeybindsConfig {
     /// Post-load repair: drops keyless binds and keeps only the first bind on any
@@ -621,17 +709,18 @@ mod tests {
     fn targets() -> Targets {
         Targets {
             scenes: vec!["Default".into(), "Live".into()],
-            sources: vec!["Microphone 1".into()],
+            sources: vec!["Microphone 1".into(), "Media Player".into()],
             buses: vec!["Music".into()],
+            media_sources: vec!["Media Player".into()],
         }
     }
 
     #[test]
     fn the_catalogue_expands_one_row_per_target() {
         let all = catalogue(&targets());
-        // Streaming 2, Scenes 2 + 2 scenes, Monitoring 1 + 1 source + 1 bus,
-        // Muting the same 3.
-        assert_eq!(all.len(), 2 + 2 + 2 + 3 + 3);
+        // Streaming 2, Scenes 2 + 2 scenes, Monitoring 1 + 2 sources + 1 bus,
+        // Muting the same 4, Media player 3 actions on the one media source.
+        assert_eq!(all.len(), 2 + 2 + 2 + 4 + 4 + 3);
         assert!(all.contains(&BindAction::SwitchScene {
             scene: "Live".into()
         }));
@@ -722,6 +811,38 @@ mod tests {
         config.set(BindAction::ToggleStream, Chord::default(), false);
         assert!(config.find(&BindAction::ToggleStream).is_none());
         assert_eq!(config.binds.len(), 1);
+    }
+
+    /// The first media player added gets CTRL+O; the second does not take it
+    /// away from it, and nothing takes it from a user who bound it elsewhere.
+    #[test]
+    fn the_first_media_player_gets_the_open_file_default() {
+        let mut config = KeybindsConfig::default();
+        assert!(config.seed_media_defaults("Media Player 1"));
+        assert_eq!(
+            config
+                .find(&BindAction::OpenTrack {
+                    source: "Media Player 1".into()
+                })
+                .map(|b| b.key.label())
+                .as_deref(),
+            Some("CTRL+O")
+        );
+
+        assert!(!config.seed_media_defaults("Media Player 2"));
+        assert!(
+            config
+                .find(&BindAction::OpenTrack {
+                    source: "Media Player 2".into()
+                })
+                .is_none()
+        );
+        // And seeding the same source twice is not a way to move its chord.
+        assert!(!config.seed_media_defaults("Media Player 1"));
+
+        let mut taken = KeybindsConfig::default();
+        taken.set(BindAction::NextScene, DEFAULT_OPEN_TRACK, false);
+        assert!(!taken.seed_media_defaults("Media Player 1"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod json_store;
 mod keybind;
 mod logging;
 mod mastodon;
+mod media;
 mod net;
 mod secret;
 mod soundpack;
@@ -113,6 +114,7 @@ fn main() {
             orphaned_plugins: RefCell::new(Vec::new()),
             chain_library: RefCell::new(chain_library.clone()),
             cues: Default::default(),
+            media: Default::default(),
             open_editors: RefCell::new(Vec::new()),
             shutting_down: std::cell::Cell::new(false),
             config_dirty: std::cell::Cell::new(false),

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -1,0 +1,301 @@
+//! The Media Player source: a folder of music, played into the mixer.
+//!
+//! Two halves. This file is the pure one — which files count as music, what
+//! order they play in — and [`player`] is the worker thread that decodes them
+//! and feeds [`crate::audio::ExternalFeeds`]. The UI-side lifecycle (one worker
+//! per media source in the active scene) is [`crate::ui::media`].
+//!
+//! A media player is an ordinary mixer source in every respect that matters: it
+//! has a strip, a fader, a mute, sends, and its own monitor toggle. What is
+//! special about it is the ducking, and that is not here either — the engine
+//! owns it, because only the engine can see what every *other* source is doing
+//! in the same block (see [`crate::audio::mixer::Ducker`]).
+
+pub mod player;
+
+use rand::seq::SliceRandom;
+use std::path::{Path, PathBuf};
+
+/// The file extensions the player will try, lowercased.
+///
+/// This is symphonia's coverage and nothing more: a file it cannot decode would
+/// be picked, announced, and then produce silence for as long as the track
+/// would have lasted, which is worse than never picking it. `.opus` is the
+/// notable absence — symphonia 0.5 has no Opus decoder — as are `.wma` and
+/// `.ape`, which it has never supported.
+pub const SUPPORTED_EXTENSIONS: &[&str] = &[
+    "mp3", "m4a", "m4b", "mp4", "aac", "flac", "ogg", "oga", "wav", "wave", "aif", "aiff", "aifc",
+    "caf", "mka", "mp1", "mp2",
+];
+
+/// A ceiling on how many files one folder contributes, so pointing a source at
+/// a drive root cannot spend the session walking it.
+const MAX_FILES: usize = 50_000;
+
+/// A ceiling on how deep the walk goes, for the same reason.
+const MAX_DEPTH: usize = 12;
+
+pub fn is_supported(path: &Path) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase())
+        .is_some_and(|e| SUPPORTED_EXTENSIONS.contains(&e.as_str()))
+}
+
+/// What the user is told a file is called: its name without the extension.
+pub fn track_title(path: &Path) -> String {
+    path.file_stem()
+        .or_else(|| path.file_name())
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.display().to_string())
+}
+
+/// Every playable file under `root`, including its subfolders, in a stable
+/// order.
+///
+/// Subfolders are included because a music folder is almost always a folder of
+/// album folders, and sorted because that order is what "shuffle off" means —
+/// without it the order would be whatever the filesystem happened to hand back,
+/// which is neither alphabetical nor stable between runs.
+pub fn scan_folder(root: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let mut stack = vec![(root.to_path_buf(), 0usize)];
+    while let Some((dir, depth)) = stack.pop() {
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            // A folder that cannot be read (permissions, a disconnected drive)
+            // is skipped rather than failing the scan: the rest of the library
+            // is still playable, and the user hears about an empty result
+            // through the source's own label.
+            Err(e) => {
+                log::debug!("Media player: skipping {}: {e}", dir.display());
+                continue;
+            }
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            match entry.file_type() {
+                // Symlinked directories are not followed: a link back up the
+                // tree would make the walk unbounded.
+                Ok(kind) if kind.is_dir() && depth < MAX_DEPTH => stack.push((path, depth + 1)),
+                Ok(kind) if kind.is_file() && is_supported(&path) => files.push(path),
+                _ => {}
+            }
+            if files.len() >= MAX_FILES {
+                log::warn!(
+                    "Media player: {} holds more than {MAX_FILES} playable files; the rest are ignored",
+                    root.display()
+                );
+                files.sort();
+                return files;
+            }
+        }
+    }
+    files.sort();
+    files
+}
+
+/// The order a folder's files play in, and where the player is up to.
+///
+/// Exhausting the list is not the end of anything: [`Playlist::next`] wraps,
+/// reshuffling as it goes, so a source left alone plays forever.
+pub struct Playlist {
+    files: Vec<PathBuf>,
+    /// Indices into `files`, in playing order.
+    order: Vec<usize>,
+    /// How far into `order` the player has got.
+    position: usize,
+    shuffle: bool,
+}
+
+impl Playlist {
+    pub fn new(files: Vec<PathBuf>, shuffle: bool) -> Self {
+        let mut playlist = Self {
+            files,
+            order: Vec::new(),
+            position: 0,
+            shuffle,
+        };
+        playlist.reorder(None);
+        playlist
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.files.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.files.len()
+    }
+
+    /// The files this playlist was built from, in folder order. Compared
+    /// against a fresh scan so an unchanged folder does not reshuffle a pass
+    /// that is already in progress.
+    pub fn files(&self) -> &[PathBuf] {
+        &self.files
+    }
+
+    /// The next file to play, wrapping (and reshuffling) at the end.
+    pub fn next(&mut self) -> Option<PathBuf> {
+        let picked = self.peek()?;
+        self.position += 1;
+        // Wrapped eagerly, the moment the pass runs out, rather than on the way
+        // into the next `next()`. That is what makes [`Playlist::peek`] able to
+        // answer at all: deferring the reshuffle leaves the first track of the
+        // next pass genuinely undecided, and "skip to the next track" has to be
+        // able to say what it is about to play before it plays it.
+        if self.position >= self.order.len() {
+            self.reorder(self.order.last().copied());
+            self.position = 0;
+        }
+        Some(picked)
+    }
+
+    /// The file [`Playlist::next`] would return, without taking it.
+    ///
+    /// This is what the announcement on a skip is built from, so it has to be
+    /// the truth rather than a guess — see the eager wrap in `next`.
+    pub fn peek(&self) -> Option<PathBuf> {
+        let index = *self.order.get(self.position)?;
+        self.files.get(index).cloned()
+    }
+
+    /// Rebuilds the play order. `avoid_first` is the track that just finished:
+    /// a fresh shuffle is allowed to start with it, which is the one repeat a
+    /// listener always notices, so it is moved out of the way.
+    fn reorder(&mut self, avoid_first: Option<usize>) {
+        self.order = (0..self.files.len()).collect();
+        if !self.shuffle {
+            return;
+        }
+        self.order.shuffle(&mut rand::thread_rng());
+        if self.order.len() > 1 && self.order.first().copied() == avoid_first {
+            self.order.swap(0, 1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn files(count: usize) -> Vec<PathBuf> {
+        (0..count)
+            .map(|n| PathBuf::from(format!("track{n}.mp3")))
+            .collect()
+    }
+
+    #[test]
+    fn only_decodable_extensions_are_picked_up() {
+        assert!(is_supported(Path::new("song.mp3")));
+        assert!(is_supported(Path::new("song.FLAC")), "case-insensitive");
+        assert!(!is_supported(Path::new("cover.jpg")));
+        assert!(!is_supported(Path::new("notes.txt")));
+        // No decoder for these, so they must never be queued.
+        assert!(!is_supported(Path::new("song.opus")));
+        assert!(!is_supported(Path::new("song.wma")));
+        assert!(!is_supported(Path::new("noextension")));
+    }
+
+    #[test]
+    fn a_track_is_named_by_its_filename_without_the_extension() {
+        assert_eq!(track_title(Path::new(r"C:\music\01 Hello.mp3")), "01 Hello");
+    }
+
+    /// Without shuffle the list is the folder's own order, over and over.
+    #[test]
+    fn in_order_playback_wraps_round() {
+        let mut playlist = Playlist::new(files(3), false);
+        let played: Vec<PathBuf> = (0..7).filter_map(|_| playlist.next()).collect();
+        assert_eq!(
+            played,
+            vec![
+                PathBuf::from("track0.mp3"),
+                PathBuf::from("track1.mp3"),
+                PathBuf::from("track2.mp3"),
+                PathBuf::from("track0.mp3"),
+                PathBuf::from("track1.mp3"),
+                PathBuf::from("track2.mp3"),
+                PathBuf::from("track0.mp3"),
+            ]
+        );
+    }
+
+    /// A shuffle that repeats a track before playing the others is the thing
+    /// users notice and complain about, so a pass plays each file exactly once.
+    #[test]
+    fn a_shuffled_pass_plays_every_file_once() {
+        let mut playlist = Playlist::new(files(20), true);
+        let mut played: Vec<PathBuf> = (0..20).filter_map(|_| playlist.next()).collect();
+        played.sort();
+        let mut expected = files(20);
+        expected.sort();
+        assert_eq!(played, expected);
+    }
+
+    /// The one repeat a wrap can produce: the last track of a pass coming back
+    /// as the first of the next.
+    #[test]
+    fn a_reshuffle_does_not_repeat_the_track_that_just_played() {
+        for _ in 0..200 {
+            let mut playlist = Playlist::new(files(4), true);
+            let played: Vec<PathBuf> = (0..8).filter_map(|_| playlist.next()).collect();
+            assert_ne!(played[3], played[4], "repeated across the wrap");
+        }
+    }
+
+    /// What "skip to the next track" announces has to be what then plays,
+    /// including across the wrap where a reshuffle happens.
+    #[test]
+    fn peek_is_what_next_hands_back() {
+        for shuffle in [false, true] {
+            let mut playlist = Playlist::new(files(4), shuffle);
+            for _ in 0..12 {
+                let peeked = playlist.peek();
+                assert_eq!(peeked, playlist.next(), "shuffle: {shuffle}");
+                assert!(peeked.is_some());
+            }
+        }
+    }
+
+    #[test]
+    fn an_empty_playlist_has_nothing_to_peek_at() {
+        assert_eq!(Playlist::new(Vec::new(), true).peek(), None);
+    }
+
+    #[test]
+    fn an_empty_folder_plays_nothing_rather_than_looping() {
+        let mut playlist = Playlist::new(Vec::new(), true);
+        assert!(playlist.is_empty());
+        assert_eq!(playlist.next(), None);
+    }
+
+    #[test]
+    fn one_file_repeats_rather_than_stopping() {
+        let mut playlist = Playlist::new(files(1), true);
+        assert_eq!(playlist.next(), Some(PathBuf::from("track0.mp3")));
+        assert_eq!(playlist.next(), Some(PathBuf::from("track0.mp3")));
+    }
+
+    #[test]
+    fn a_scan_finds_music_in_subfolders_and_ignores_everything_else() {
+        let root = std::env::temp_dir().join(format!("pubsplash-media-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("album")).unwrap();
+        std::fs::write(root.join("b.mp3"), b"").unwrap();
+        std::fs::write(root.join("cover.jpg"), b"").unwrap();
+        std::fs::write(root.join("album").join("a.flac"), b"").unwrap();
+
+        let found = scan_folder(&root);
+
+        assert_eq!(found.len(), 2, "{found:?}");
+        assert_eq!(found[0], root.join("album").join("a.flac"), "sorted");
+        assert_eq!(found[1], root.join("b.mp3"));
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn a_folder_that_is_not_there_scans_to_nothing() {
+        assert!(scan_folder(Path::new(r"Z:\definitely\not\here")).is_empty());
+    }
+}

--- a/src/media/player.rs
+++ b/src/media/player.rs
@@ -1,0 +1,961 @@
+//! One media player: a thread that decodes a folder of music into a source's
+//! ring, and the handle the UI drives it with.
+//!
+//! ## Why a thread per source
+//!
+//! Feeding [`ExternalFeeds`] is paced by the mixer's drain rate — pushing a
+//! track takes as long as the track lasts — so it cannot happen on the UI
+//! thread, and it cannot happen on the audio thread either: this opens files,
+//! allocates, and runs a decoder. It is the same shape as
+//! [`crate::ui::cue_feed`], one worker per source, except that this one is
+//! never idle while its scene is active.
+//!
+//! ## Decoding
+//!
+//! A track is decoded *as it plays*, one packet at a time, and never held in
+//! memory whole: five minutes of 48 kHz stereo f32 is 115 MB, and a library
+//! folder is hours of it. Each packet is widened to stereo and resampled to
+//! [`SAMPLE_RATE`] through a [`StereoStream`], which carries its interpolation
+//! state across packets — resampling each packet on its own would put a click
+//! at every packet boundary, forty times a second.
+//!
+//! ## Waiting
+//!
+//! Every wait in here is a `recv_timeout` on the command channel rather than a
+//! sleep, so pause, skip and shutdown are acted on the moment they arrive
+//! however long the timeout is. The timeouts themselves exist only for the one
+//! thing that has no event behind it: the ring filling up, which drains at the
+//! mixer's own pace.
+
+use crate::audio::convert::{StereoStream, convert_to_stereo};
+use crate::audio::mixer::SAMPLE_RATE;
+use crate::audio::{ExternalFeeds, FeedResult};
+use crossbeam_channel::{Receiver, RecvTimeoutError, Sender};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use symphonia::core::audio::SampleBuffer;
+use symphonia::core::codecs::DecoderOptions;
+use symphonia::core::errors::Error as SymphoniaError;
+use symphonia::core::formats::FormatOptions;
+use symphonia::core::io::MediaSourceStream;
+use symphonia::core::meta::MetadataOptions;
+use symphonia::core::probe::Hint;
+
+use super::{Playlist, scan_folder, track_title};
+
+/// How far ahead of the mixer this worker is allowed to decode, in samples.
+///
+/// The source's ring holds a whole second, and filling it would be the obvious
+/// thing to do — but everything in that ring **will be heard**, whatever the
+/// user presses next. Pause and next track would then take up to a second to
+/// take effect, on a control whose whole job is to be immediate. A quarter of a
+/// second is still ten times the length of a decoded packet, so a disk seek or
+/// a slow file cannot starve the mixer, and it is short enough that a skip
+/// sounds instant.
+const MAX_QUEUED: usize =
+    (crate::audio::mixer::SAMPLE_RATE as usize / 4) * crate::audio::mixer::CHANNELS;
+
+/// How long to wait for a command when the only other thing to wait for is the
+/// ring draining. A fraction of [`MAX_QUEUED`], so topping the ring back up is
+/// never late.
+const RING_WAIT: Duration = Duration::from_millis(50);
+
+/// How long to wait between attempts when the source's ring is not there yet.
+/// A scene switch sends the engine its new sources and starts these workers in
+/// the same breath, so a worker can beat its own ring into existence by a block
+/// or two.
+const NO_RING_WAIT: Duration = Duration::from_millis(100);
+
+/// How long a missing ring is tolerated before it is worth a log line.
+const NO_RING_PATIENCE: Duration = Duration::from_secs(3);
+
+/// How long to wait, when there is nothing to play, before looking at the
+/// folder again — the case where the user is filling it while Pubsplash runs.
+const EMPTY_RESCAN: Duration = Duration::from_secs(15);
+
+/// How often the folder is re-read while playing, so files added during a long
+/// session join the rotation. Checked between tracks, never mid-track.
+const RESCAN_INTERVAL: Duration = Duration::from_secs(300);
+
+/// How long to wait after a run of unplayable files before trying again.
+/// Without it, a folder Pubsplash cannot read would spin this thread at the
+/// speed of `File::open`.
+const FAILURE_BACKOFF: Duration = Duration::from_secs(5);
+
+/// How many files in a row may fail before that backoff.
+///
+/// Capped well below the size of a real library on purpose. The failure this
+/// guards against is not one bad file — that is skipped and forgotten — but the
+/// whole folder becoming unreadable at once, which is what a disconnected drive
+/// looks like. Walking a thousand paths to find that out would take a thousand
+/// log lines to say it.
+const FAILURE_STREAK: usize = 10;
+
+/// What a media player is doing, for the source's label in the Sources list.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum PlaybackState {
+    /// No folder is set: the source is configured but has nothing to play.
+    #[default]
+    NoFolder,
+    /// The folder holds no file this build can decode.
+    NoFiles,
+    Playing,
+    Paused,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Status {
+    pub state: PlaybackState,
+    /// The track playing (or paused), without its extension.
+    pub track: Option<String>,
+    /// The track a skip would move to, without its extension.
+    ///
+    /// Published by the worker rather than worked out by the caller because the
+    /// playlist lives here — and it is what "skip to the next track" is
+    /// announced as, so the announcement names the track the user is about to
+    /// hear instead of telling them something they already know.
+    pub next: Option<String>,
+}
+
+/// What the UI can ask a running player to do.
+pub enum Command {
+    PlayPause,
+    /// Abandon the current track and start the next one.
+    Next,
+    /// Abandon the current track and play this file, then carry on with the
+    /// folder. The file does not have to be in the folder, or in any folder this
+    /// source knows about — it is a one-off, and nothing about it is remembered.
+    PlayFile(std::path::PathBuf),
+    /// The source's settings changed. The folder is re-read; playback continues
+    /// with the next track from the new list.
+    Reload { folder: String, shuffle: bool },
+}
+
+/// A running media player. Dropping the handle does **not** stop the thread —
+/// use [`Player::stop`], which is what guarantees the old worker is gone before
+/// a new one can be pushing into the same ring.
+pub struct Player {
+    commands: Sender<Command>,
+    status: Arc<Mutex<Status>>,
+    stop: Arc<AtomicBool>,
+    thread: Option<std::thread::JoinHandle<()>>,
+    /// What this worker was started with, so the UI can tell whether a config
+    /// edit actually changed anything.
+    pub folder: String,
+    pub shuffle: bool,
+}
+
+impl Player {
+    pub fn start(
+        source_name: String,
+        feeds: ExternalFeeds,
+        folder: String,
+        shuffle: bool,
+        generation: Arc<AtomicU64>,
+    ) -> Self {
+        let (tx, rx) = crossbeam_channel::unbounded();
+        let status = Arc::new(Mutex::new(Status::default()));
+        let stop = Arc::new(AtomicBool::new(false));
+        let thread = std::thread::Builder::new()
+            .name("media-player".into())
+            .spawn({
+                let mut worker = Worker {
+                    source: source_name,
+                    feeds,
+                    commands: rx,
+                    status: status.clone(),
+                    generation,
+                    stop: stop.clone(),
+                    folder: folder.clone(),
+                    shuffle,
+                    paused: false,
+                    playlist: Playlist::new(Vec::new(), shuffle),
+                    pending: None,
+                    last_scan: None,
+                    failures: 0,
+                };
+                move || worker.run()
+            })
+            .ok();
+        Self {
+            commands: tx,
+            status,
+            stop,
+            thread,
+            folder,
+            shuffle,
+        }
+    }
+
+    pub fn status(&self) -> Status {
+        crate::audio::device::lock_recovering(&self.status, "Media player status").clone()
+    }
+
+    pub fn send(&self, command: Command) {
+        let _ = self.commands.send(command);
+    }
+
+    /// The worker's thread id, so a test can tell "this player is still the one
+    /// that was playing" from "it was stopped and started again".
+    #[cfg(test)]
+    pub fn thread_id(&self) -> Option<std::thread::ThreadId> {
+        self.thread.as_ref().map(|t| t.thread().id())
+    }
+
+    /// Stops the worker and waits for it to let go of the ring.
+    ///
+    /// The join is what makes this safe rather than tidy: a detached worker
+    /// would keep pushing into `ExternalFeeds` by source *name*, and a scene
+    /// with a media player of the same name would find a stranger's audio in
+    /// its ring. Every wait in the worker is a `recv_timeout`, and dropping the
+    /// sender ends all of them at once, so this returns in about the time it
+    /// takes to notice — never the length of a track.
+    pub fn stop(mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        drop(self.commands);
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+/// How a step ended: what the caller should do next.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Flow {
+    /// Carry on with what you were doing.
+    Go,
+    /// Stop the current track and pick another.
+    NextTrack,
+    /// The playlist has been replaced; stop the current track.
+    Reloaded,
+    /// The worker is finished.
+    Stop,
+}
+
+struct Worker {
+    source: String,
+    feeds: ExternalFeeds,
+    commands: Receiver<Command>,
+    status: Arc<Mutex<Status>>,
+    generation: Arc<AtomicU64>,
+    stop: Arc<AtomicBool>,
+    folder: String,
+    shuffle: bool,
+    paused: bool,
+    playlist: Playlist,
+    /// A file the user picked with Open file, to play before going back to the
+    /// folder. Taken by the next pass round the loop, so it survives being set
+    /// from anywhere a command is drained.
+    pending: Option<PathBuf>,
+    /// When the folder was last read, so a long session picks up new files.
+    last_scan: Option<Instant>,
+    /// Tracks that failed to produce any audio since the last one that did.
+    failures: usize,
+}
+
+impl Worker {
+    /// The waits in here test only for [`Flow::Stop`], which is safe *here* and
+    /// nowhere else: every one of them is followed by `continue`, and the top of
+    /// this loop is where a skip or a reload is acted on anyway. Inside
+    /// [`Worker::feed`] the same shape drops the command on the floor — see the
+    /// note there.
+    fn run(&mut self) {
+        self.rescan();
+        loop {
+            if self.stopping() {
+                return;
+            }
+            // A file the user opened outright is played before anything the
+            // folder has to say — including when the folder is empty, or not set
+            // at all, which is a perfectly reasonable way to use this source.
+            if let Some(path) = self.pending.take() {
+                self.set_status(PlaybackState::Playing, Some(track_title(&path)));
+                if self.play(&path) == Flow::Stop {
+                    return;
+                }
+                continue;
+            }
+            if self.playlist.is_empty() {
+                let state = if self.folder.trim().is_empty() {
+                    PlaybackState::NoFolder
+                } else {
+                    PlaybackState::NoFiles
+                };
+                self.set_status(state, None);
+                if self.wait(EMPTY_RESCAN) == Flow::Stop {
+                    return;
+                }
+                if self.folder_is_stale(EMPTY_RESCAN) {
+                    self.rescan();
+                }
+                continue;
+            }
+            if self.paused {
+                // Paused with nothing to do: the wait ends the moment a command
+                // arrives, so this costs one wakeup a second.
+                if self.wait(Duration::from_secs(1)) == Flow::Stop {
+                    return;
+                }
+                continue;
+            }
+            // A run of files that produced no audio at all: back off rather
+            // than reopening them as fast as the disk allows, and read the
+            // folder again — the usual cause is that it is not there any more.
+            if self.failures >= FAILURE_STREAK.min(self.playlist.len().max(1)) {
+                self.failures = 0;
+                log::warn!(
+                    "Media player {:?}: nothing in {} could be played; trying again shortly",
+                    self.source,
+                    self.folder
+                );
+                self.last_scan = None;
+                if self.wait(FAILURE_BACKOFF) == Flow::Stop {
+                    return;
+                }
+                continue;
+            }
+            if self.folder_is_stale(RESCAN_INTERVAL) {
+                self.rescan();
+            }
+            let Some(track) = self.playlist.next() else {
+                continue;
+            };
+            self.set_status(PlaybackState::Playing, Some(track_title(&track)));
+            if self.play(&track) == Flow::Stop {
+                return;
+            }
+        }
+    }
+
+    fn stopping(&self) -> bool {
+        self.stop.load(Ordering::Relaxed)
+    }
+
+    /// Re-reads the folder. An unchanged list keeps the current playlist, so a
+    /// rescan mid-session does not reshuffle what is already in progress.
+    fn rescan(&mut self) {
+        self.last_scan = Some(Instant::now());
+        let folder = self.folder.trim();
+        let files = if folder.is_empty() {
+            Vec::new()
+        } else {
+            scan_folder(Path::new(folder))
+        };
+        if files.as_slice() == self.playlist.files() {
+            return;
+        }
+        log::info!(
+            "Media player {:?}: {} playable files in {:?}",
+            self.source,
+            files.len(),
+            folder
+        );
+        self.failures = 0;
+        self.playlist = Playlist::new(files, self.shuffle);
+    }
+
+    fn folder_is_stale(&self, after: Duration) -> bool {
+        self.last_scan.is_none_or(|at| at.elapsed() >= after)
+    }
+
+    /// Publishes what this player is doing. The *upcoming* track is read off
+    /// the playlist here rather than passed in, so every path that changes the
+    /// status refreshes it — a rescan or a reload moves it as surely as a track
+    /// ending does.
+    fn set_status(&self, state: PlaybackState, track: Option<String>) {
+        let next = Status {
+            state,
+            track,
+            next: self.playlist.peek().map(|path| track_title(&path)),
+        };
+        let mut status =
+            crate::audio::device::lock_recovering(&self.status, "Media player status");
+        if *status == next {
+            return;
+        }
+        *status = next;
+        drop(status);
+        // The pump notices the counter moved and re-derives the source's label;
+        // see `ui::media`.
+        self.generation.fetch_add(1, Ordering::Relaxed);
+        wxdragon::wake_up_idle();
+    }
+
+    /// Waits up to `timeout` for a command, acting on whatever arrives.
+    fn wait(&mut self, timeout: Duration) -> Flow {
+        match self.commands.recv_timeout(timeout) {
+            Ok(command) => self.apply(command),
+            Err(RecvTimeoutError::Timeout) => {
+                if self.stopping() {
+                    Flow::Stop
+                } else {
+                    Flow::Go
+                }
+            }
+            // The handle is gone, which only happens through `Player::stop`.
+            Err(RecvTimeoutError::Disconnected) => Flow::Stop,
+        }
+    }
+
+    /// Acts on everything already queued, without waiting.
+    fn drain_commands(&mut self) -> Flow {
+        loop {
+            match self.commands.try_recv() {
+                Ok(command) => match self.apply(command) {
+                    Flow::Go => {}
+                    other => return other,
+                },
+                Err(crossbeam_channel::TryRecvError::Empty) => {
+                    return if self.stopping() { Flow::Stop } else { Flow::Go };
+                }
+                Err(crossbeam_channel::TryRecvError::Disconnected) => return Flow::Stop,
+            }
+        }
+    }
+
+    fn apply(&mut self, command: Command) -> Flow {
+        match command {
+            Command::PlayPause => {
+                self.paused = !self.paused;
+                Flow::Go
+            }
+            Command::Next => {
+                // Skipping while paused starts playing again: the user asked
+                // for a different track, not for a different silence.
+                self.paused = false;
+                Flow::NextTrack
+            }
+            // The same skip, to a file of the user's choosing rather than the
+            // playlist's. Nothing is remembered: when it ends, the folder picks
+            // up exactly where it would have.
+            Command::PlayFile(path) => {
+                self.paused = false;
+                self.pending = Some(path);
+                Flow::NextTrack
+            }
+            Command::Reload { folder, shuffle } => {
+                self.folder = folder;
+                self.shuffle = shuffle;
+                // Forces a real rescan even if the list is unchanged, since the
+                // shuffle setting may be what moved.
+                self.playlist = Playlist::new(Vec::new(), shuffle);
+                self.rescan();
+                Flow::Reloaded
+            }
+        }
+    }
+
+    /// Decodes one file into the source's ring, in step with the mixer.
+    fn play(&mut self, path: &Path) -> Flow {
+        log::debug!("Media player {:?}: playing {}", self.source, path.display());
+        match self.decode(path) {
+            Ok(flow) => flow,
+            Err(message) => {
+                // One line per unreadable file, then on to the next: a folder
+                // with a broken file in it is not a broken media player.
+                log::warn!(
+                    "Media player {:?}: could not play {}: {message}",
+                    self.source,
+                    path.display()
+                );
+                self.failures += 1;
+                Flow::Go
+            }
+        }
+    }
+
+    fn decode(&mut self, path: &Path) -> Result<Flow, String> {
+        let file = std::fs::File::open(path).map_err(|e| e.to_string())?;
+        let stream = MediaSourceStream::new(Box::new(file), Default::default());
+        let mut hint = Hint::new();
+        if let Some(extension) = path.extension().and_then(|e| e.to_str()) {
+            hint.with_extension(extension);
+        }
+        let probed = symphonia::default::get_probe()
+            .format(
+                &hint,
+                stream,
+                // Gapless playback trims the encoder padding an MP3 carries at
+                // both ends, which is the difference between a seamless album
+                // and a click between every track.
+                &FormatOptions {
+                    enable_gapless: true,
+                    ..Default::default()
+                },
+                &MetadataOptions::default(),
+            )
+            .map_err(|e| e.to_string())?;
+        let mut format = probed.format;
+        let track = format
+            .default_track()
+            .ok_or_else(|| "the file has no audio track".to_string())?;
+        let track_id = track.id;
+        let mut decoder = symphonia::default::get_codecs()
+            .make(&track.codec_params, &DecoderOptions::default())
+            .map_err(|e| e.to_string())?;
+
+        let mut buffer: Option<SampleBuffer<f32>> = None;
+        let mut resampler: Option<(u32, StereoStream)> = None;
+        let mut played_anything = false;
+
+        loop {
+            // Commands first, so skip and pause are answered between packets
+            // rather than at the end of the track.
+            match self.drain_commands() {
+                Flow::Go => {}
+                other => return Ok(other),
+            }
+            if self.paused && self.wait_while_paused() == Flow::Stop {
+                return Ok(Flow::Stop);
+            }
+            let packet = match format.next_packet() {
+                Ok(packet) => packet,
+                // Symphonia reports a clean end of stream as an IO error, and a
+                // torn tail is still worth having played, so any error here ends
+                // the track rather than failing it.
+                Err(_) => break,
+            };
+            if packet.track_id() != track_id {
+                continue;
+            }
+            let decoded = match decoder.decode(&packet) {
+                Ok(decoded) => decoded,
+                // A damaged packet is skipped; the format layer has already
+                // resynchronized by the time it says so.
+                Err(SymphoniaError::DecodeError(_)) => continue,
+                Err(e) => {
+                    if played_anything {
+                        break;
+                    }
+                    return Err(e.to_string());
+                }
+            };
+            let spec = *decoded.spec();
+            let buffer = buffer
+                .get_or_insert_with(|| SampleBuffer::<f32>::new(decoded.capacity() as u64, spec));
+            buffer.copy_interleaved_ref(decoded);
+            let channels = spec.channels.count().max(1);
+            let stereo = convert_to_stereo(buffer.samples(), channels)?;
+
+            let samples = if spec.rate == SAMPLE_RATE {
+                stereo
+            } else {
+                // Rebuilt only if the file's rate actually changes mid-stream,
+                // which is legal in a few containers and vanishingly rare.
+                if !matches!(&resampler, Some((rate, _)) if *rate == spec.rate) {
+                    resampler = Some((spec.rate, StereoStream::new(spec.rate)));
+                }
+                match &mut resampler {
+                    Some((_, stream)) => stream.push(&stereo),
+                    None => unreachable!("a resampler was just installed"),
+                }
+            };
+            if samples.is_empty() {
+                continue;
+            }
+            played_anything = true;
+            match self.feed(&samples) {
+                Flow::Go => {}
+                other => return Ok(other),
+            }
+        }
+
+        // The resampler holds back the frame it still needed a neighbour for.
+        if let Some((_, stream)) = &mut resampler {
+            let tail = stream.finish();
+            if !tail.is_empty() {
+                played_anything = true;
+                match self.feed(&tail) {
+                    Flow::Go => {}
+                    other => return Ok(other),
+                }
+            }
+        }
+
+        if played_anything {
+            self.failures = 0;
+            Ok(Flow::Go)
+        } else {
+            Err("no audio could be decoded from it".to_string())
+        }
+    }
+
+    /// Holds the current track where it is until play resumes. The ring drains
+    /// into silence on its own, which is what makes pause immediate.
+    fn wait_while_paused(&mut self) -> Flow {
+        let track = self.status().track;
+        self.set_status(PlaybackState::Paused, track.clone());
+        while self.paused {
+            match self.wait(Duration::from_secs(1)) {
+                Flow::Go => {}
+                other => return other,
+            }
+        }
+        self.set_status(PlaybackState::Playing, track);
+        Flow::Go
+    }
+
+    fn status(&self) -> Status {
+        crate::audio::device::lock_recovering(&self.status, "Media player status").clone()
+    }
+
+    /// Pushes a decoded chunk into the source's ring, pacing to the mixer.
+    ///
+    /// **Every wait in here must return what it was handed.** [`Worker::wait`]
+    /// takes a command off the channel and acts on it, so a flow it produces is
+    /// the only remaining evidence that the command arrived — a caller that
+    /// tests it against one variant and carries on has silently eaten a
+    /// keypress. This loop is where a media player spends nearly all of its
+    /// life (it keeps a quarter of a second queued and waits out the rest), so
+    /// nearly every skip the user presses is answered here, and testing only
+    /// for [`Flow::Stop`] is what made next track do nothing at all.
+    fn feed(&mut self, samples: &[f32]) -> Flow {
+        let mut offset = 0;
+        let mut missing_since: Option<Instant> = None;
+        while offset < samples.len() {
+            match self.drain_commands() {
+                Flow::Go => {}
+                other => return other,
+            }
+            if self.paused {
+                match self.wait_while_paused() {
+                    Flow::Go => {}
+                    other => return other,
+                }
+            }
+            // Stay only just ahead of the mixer. See `MAX_QUEUED`.
+            if self
+                .feeds
+                .queued(&self.source)
+                .is_some_and(|queued| queued >= MAX_QUEUED)
+            {
+                match self.wait(RING_WAIT) {
+                    Flow::Go => {}
+                    other => return other,
+                }
+                continue;
+            }
+            match self.feeds.push(&self.source, &samples[offset..]) {
+                FeedResult::Done => return Flow::Go,
+                FeedResult::Full { accepted } => {
+                    offset += accepted;
+                    missing_since = None;
+                    if offset < samples.len() {
+                        match self.wait(RING_WAIT) {
+                            Flow::Go => {}
+                            other => return other,
+                        }
+                    }
+                }
+                // The source is not in the mixer right now. Waiting rather than
+                // dropping the audio: this is the ordinary state for the block
+                // or two between a scene switch and the engine applying it, and
+                // a worker whose source is really gone is stopped and joined.
+                FeedResult::Gone => {
+                    let since = missing_since.get_or_insert_with(Instant::now);
+                    if since.elapsed() >= NO_RING_PATIENCE {
+                        log::debug!(
+                            "Media player {:?}: waiting for the mixer to take this source",
+                            self.source
+                        );
+                        missing_since = Some(Instant::now());
+                    }
+                    match self.wait(NO_RING_WAIT) {
+                        Flow::Go => {}
+                        other => return other,
+                    }
+                }
+            }
+        }
+        Flow::Go
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A folder holding one WAV of a tone, at a rate that is not the engine's
+    /// so the resampling path is exercised too.
+    fn folder_with_a_tone(name: &str) -> std::path::PathBuf {
+        use hound::{SampleFormat, WavSpec, WavWriter};
+        let folder = std::env::temp_dir().join(format!("pubsplash-player-{name}"));
+        let _ = std::fs::remove_dir_all(&folder);
+        std::fs::create_dir_all(&folder).unwrap();
+        let rate = 44_100;
+        let spec = WavSpec {
+            channels: 2,
+            sample_rate: rate,
+            bits_per_sample: 16,
+            sample_format: SampleFormat::Int,
+        };
+        let mut writer = WavWriter::create(folder.join("tone.wav"), spec).unwrap();
+        // Two seconds, so the ring fills and the player is still mid-track when
+        // the test looks.
+        for frame in 0..rate * 2 {
+            let phase = frame as f32 / rate as f32 * 440.0 * std::f32::consts::TAU;
+            let sample = (phase.sin() * 16_384.0) as i16;
+            writer.write_sample(sample).unwrap();
+            writer.write_sample(sample).unwrap();
+        }
+        writer.finalize().unwrap();
+        folder
+    }
+
+    /// A folder of several named tracks, so a test can tell which one is
+    /// playing. Long enough that nothing reaches its end on its own.
+    fn folder_of_tracks(name: &str, tracks: &[&str]) -> std::path::PathBuf {
+        use hound::{SampleFormat, WavSpec, WavWriter};
+        let folder = std::env::temp_dir().join(format!("pubsplash-player-{name}"));
+        let _ = std::fs::remove_dir_all(&folder);
+        std::fs::create_dir_all(&folder).unwrap();
+        let rate = 48_000;
+        for track in tracks {
+            let spec = WavSpec {
+                channels: 2,
+                sample_rate: rate,
+                bits_per_sample: 16,
+                sample_format: SampleFormat::Int,
+            };
+            let mut writer =
+                WavWriter::create(folder.join(format!("{track}.wav")), spec).unwrap();
+            for frame in 0..rate * 30 {
+                let phase = frame as f32 / rate as f32 * 440.0 * std::f32::consts::TAU;
+                let sample = (phase.sin() * 16_384.0) as i16;
+                writer.write_sample(sample).unwrap();
+                writer.write_sample(sample).unwrap();
+            }
+            writer.finalize().unwrap();
+        }
+        folder
+    }
+
+    /// Skipping moves to the next track rather than staying where it was.
+    #[test]
+    fn next_track_starts_the_next_track() {
+        let folder = folder_of_tracks("next", &["a", "b"]);
+        let feeds = ExternalFeeds::default();
+        let mut ring =
+            feeds.park_for_test("Media Player", crate::audio::mixer::SAMPLE_RATE as usize);
+        let player = Player::start(
+            "Media Player".to_string(),
+            feeds,
+            folder.to_string_lossy().into_owned(),
+            false,
+            Arc::new(AtomicU64::new(0)),
+        );
+
+        // Drain like the mixer would, so the worker is doing real work rather
+        // than parked against a full ring.
+        let drain = Arc::new(AtomicBool::new(false));
+        let drainer = std::thread::spawn({
+            let drain = drain.clone();
+            move || {
+                while !drain.load(Ordering::Relaxed) {
+                    let slots = ring.slots();
+                    if slots > 0 && let Ok(chunk) = ring.read_chunk(slots) {
+                        chunk.commit_all();
+                    }
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+            }
+        });
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while player.status().track.as_deref() != Some("a") && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert_eq!(player.status().track.as_deref(), Some("a"), "first track");
+        // What the skip about to be pressed will be announced as.
+        assert_eq!(player.status().next.as_deref(), Some("b"));
+
+        player.send(Command::Next);
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while player.status().track.as_deref() == Some("a") && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        let after = player.status();
+        drain.store(true, Ordering::Relaxed);
+        let _ = drainer.join();
+        player.stop();
+        let _ = std::fs::remove_dir_all(&folder);
+
+        assert_eq!(after.state, PlaybackState::Playing);
+        assert_eq!(after.track.as_deref(), Some("b"), "skip stayed put");
+    }
+
+    /// Open file: the chosen track interrupts what was playing, and the folder
+    /// picks up afterwards as though it had never happened.
+    #[test]
+    fn an_opened_file_plays_and_leaves_the_folder_where_it_was() {
+        let folder = folder_of_tracks("open", &["a", "b"]);
+        // Deliberately somewhere else: the point of the feature is that the file
+        // does not have to be in the source's folder.
+        let elsewhere = folder_of_tracks("open-elsewhere", &["chosen"]);
+        let feeds = ExternalFeeds::default();
+        let mut ring =
+            feeds.park_for_test("Media Player", crate::audio::mixer::SAMPLE_RATE as usize);
+        let player = Player::start(
+            "Media Player".to_string(),
+            feeds,
+            folder.to_string_lossy().into_owned(),
+            false,
+            Arc::new(AtomicU64::new(0)),
+        );
+
+        let drain = Arc::new(AtomicBool::new(false));
+        let drainer = std::thread::spawn({
+            let drain = drain.clone();
+            move || {
+                while !drain.load(Ordering::Relaxed) {
+                    let slots = ring.slots();
+                    if slots > 0 && let Ok(chunk) = ring.read_chunk(slots) {
+                        chunk.commit_all();
+                    }
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+            }
+        });
+        let wait_for = |what: &str| {
+            let deadline = Instant::now() + Duration::from_secs(10);
+            while player.status().track.as_deref() != Some(what) && Instant::now() < deadline {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            player.status()
+        };
+
+        assert_eq!(wait_for("a").track.as_deref(), Some("a"), "first track");
+        player.send(Command::PlayFile(elsewhere.join("chosen.wav")));
+        let playing = wait_for("chosen");
+
+        // And on from there: the folder resumes with the track it was up to,
+        // not with a reshuffled or restarted list.
+        player.send(Command::Next);
+        let after = wait_for("b");
+
+        drain.store(true, Ordering::Relaxed);
+        let _ = drainer.join();
+        player.stop();
+        let _ = std::fs::remove_dir_all(&folder);
+        let _ = std::fs::remove_dir_all(&elsewhere);
+
+        assert_eq!(playing.track.as_deref(), Some("chosen"));
+        assert_eq!(playing.state, PlaybackState::Playing);
+        // The folder never stopped being the folder, so a skip out of the
+        // opened file is announced as — and plays — the track that was next.
+        assert_eq!(playing.next.as_deref(), Some("b"));
+        assert_eq!(after.track.as_deref(), Some("b"));
+    }
+
+    /// The whole path in one: a file on disk is found, decoded, resampled to
+    /// the engine's rate and pushed into the source's ring.
+    #[test]
+    fn a_folder_of_music_reaches_the_mixer() {
+        let folder = folder_with_a_tone("plays");
+        let feeds = ExternalFeeds::default();
+        let mut ring = feeds.park_for_test("Media Player", crate::audio::mixer::SAMPLE_RATE as usize);
+        let player = Player::start(
+            "Media Player".to_string(),
+            feeds,
+            folder.to_string_lossy().into_owned(),
+            true,
+            Arc::new(AtomicU64::new(0)),
+        );
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while ring.slots() < 4_800 && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        let available = ring.slots();
+        let status = player.status();
+        player.stop();
+        let _ = std::fs::remove_dir_all(&folder);
+
+        assert!(available >= 4_800, "only {available} samples arrived");
+        let chunk = ring.read_chunk(4_800).unwrap();
+        let (first, _) = chunk.as_slices();
+        let peak = first.iter().fold(0f32, |max, s| max.max(s.abs()));
+        assert!(peak > 0.4, "the tone arrived silent (peak {peak})");
+        assert_eq!(status.state, PlaybackState::Playing);
+        assert_eq!(status.track.as_deref(), Some("tone"));
+    }
+
+    /// Pausing stops the audio, and the ring drains rather than being refilled.
+    #[test]
+    fn pausing_stops_the_music() {
+        let folder = folder_with_a_tone("pauses");
+        let feeds = ExternalFeeds::default();
+        let mut ring = feeds.park_for_test("Media Player", crate::audio::mixer::SAMPLE_RATE as usize);
+        let player = Player::start(
+            "Media Player".to_string(),
+            feeds,
+            folder.to_string_lossy().into_owned(),
+            true,
+            Arc::new(AtomicU64::new(0)),
+        );
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while ring.slots() < 4_800 && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        player.send(Command::PlayPause);
+        let paused_by = Instant::now() + Duration::from_secs(2);
+        while player.status().state != PlaybackState::Paused && Instant::now() < paused_by {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert_eq!(player.status().state, PlaybackState::Paused);
+
+        // Drain what was already decoded; nothing more may arrive.
+        let queued = ring.slots();
+        let chunk = ring.read_chunk(queued).unwrap();
+        chunk.commit_all();
+        std::thread::sleep(Duration::from_millis(300));
+        let after = ring.slots();
+        player.stop();
+        let _ = std::fs::remove_dir_all(&folder);
+
+        assert_eq!(after, 0, "a paused player kept feeding the mixer");
+    }
+
+    /// A player whose source has no ring at all: nothing consumes what it
+    /// decodes, which is the state a scene switch leaves it in for a block or
+    /// two. It must wait rather than spin, and it must still stop on request.
+    #[test]
+    fn a_player_with_nowhere_to_feed_still_stops() {
+        let player = Player::start(
+            "Media Player".to_string(),
+            ExternalFeeds::default(),
+            String::new(),
+            true,
+            Arc::new(AtomicU64::new(0)),
+        );
+        // No folder, so it settles into the "nothing to play" wait.
+        let started = Instant::now();
+        player.stop();
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "stop must not wait out the rescan timer"
+        );
+    }
+
+    #[test]
+    fn an_unset_folder_reports_itself_rather_than_an_error() {
+        let player = Player::start(
+            "Media Player".to_string(),
+            ExternalFeeds::default(),
+            String::new(),
+            true,
+            Arc::new(AtomicU64::new(0)),
+        );
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline && player.status().state != PlaybackState::NoFolder {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert_eq!(player.status().state, PlaybackState::NoFolder);
+        assert_eq!(player.status().track, None);
+        player.stop();
+    }
+}

--- a/src/source_name.rs
+++ b/src/source_name.rs
@@ -31,6 +31,10 @@ pub struct NameContext {
     /// keyed by engine id and then voice id. Only engines that need it are
     /// looked up, and an id the catalog has never seen is simply absent.
     pub voice_labels: HashMap<String, HashMap<String, String>>,
+    /// What each running media player is doing, keyed by identity name. Absent
+    /// means no player is running for that source, which is every media player
+    /// outside the active scene.
+    pub media: HashMap<String, crate::media::player::Status>,
 }
 
 impl NameContext {
@@ -43,6 +47,7 @@ impl NameContext {
         sources: &[SourceConfig],
         apps: HashMap<String, AppProcess>,
         failing: HashSet<String>,
+        media: HashMap<String, crate::media::player::Status>,
     ) -> Self {
         let needs_devices = sources
             .iter()
@@ -56,6 +61,7 @@ impl NameContext {
             apps,
             failing,
             voice_labels: voice_labels_for(sources),
+            media,
         }
     }
 
@@ -190,7 +196,32 @@ fn base_strip_label(source: &SourceConfig, ctx: &NameContext) -> String {
             VoiceDisplay::Default | VoiceDisplay::Unnamed => "Text-to-Speech".to_string(),
         },
         SourceKindConfig::SoundEvents(_) => "Sound Events".to_string(),
+        // The folder, not the track: this name is spoken again every time it
+        // changes (see `home::relabel_source_strips`), and a strip that renamed
+        // itself every three minutes would interrupt whoever was using the
+        // mixer. What is playing belongs in the list form below, which is
+        // refreshed in place.
+        SourceKindConfig::MediaPlayer(media) => match folder_name(&media.folder) {
+            Some(folder) => format!("Media Player ({folder})"),
+            None => "Media Player".to_string(),
+        },
     }
+}
+
+/// The last component of a folder path — "Jazz" out of `D:\music\Jazz` — which
+/// is what a user calls it. Falls back to the whole string for a path with no
+/// components (a bare drive), and answers `None` for an unset folder.
+fn folder_name(folder: &str) -> Option<&str> {
+    let folder = folder.trim().trim_end_matches(['\\', '/']);
+    if folder.is_empty() {
+        return None;
+    }
+    Some(
+        folder
+            .rsplit(['\\', '/'])
+            .find(|part| !part.is_empty())
+            .unwrap_or(folder),
+    )
 }
 
 fn list_label(source: &SourceConfig, ctx: &NameContext) -> String {
@@ -225,6 +256,43 @@ fn base_list_label(source: &SourceConfig, ctx: &NameContext) -> String {
             }
         }
         SourceKindConfig::SoundEvents(_) => "Sound Events".to_string(),
+        SourceKindConfig::MediaPlayer(media) => media_list_label(source, media, ctx),
+    }
+}
+
+/// The Sources list form of a media player, which is where what it is playing
+/// is reported.
+///
+/// A source in a scene that is not active has no player running and so no
+/// status at all — it says what it is set to and nothing about playback, which
+/// is the truth: nothing is playing.
+fn media_list_label(
+    source: &SourceConfig,
+    media: &crate::config::MediaPlayerSourceConfig,
+    ctx: &NameContext,
+) -> String {
+    use crate::media::player::PlaybackState;
+    let Some(folder) = folder_name(&media.folder) else {
+        return "Media Player: no folder set".to_string();
+    };
+    let Some(status) = ctx.media.get(&source.name) else {
+        return format!("Media Player: {folder}");
+    };
+    match (&status.state, &status.track) {
+        (PlaybackState::Playing, Some(track)) => format!("Media Player: {folder}, playing {track}"),
+        (PlaybackState::Paused, Some(track)) => {
+            format!("Media Player: {folder}, paused on {track}")
+        }
+        (PlaybackState::Paused, None) => format!("Media Player: {folder}, paused"),
+        (PlaybackState::NoFiles, _) => {
+            format!("Media Player: {folder} has no audio files Pubsplash can play")
+        }
+        // Starting up: the folder has been read but the first track has not
+        // been opened yet. A fraction of a second, and never worth its own
+        // wording.
+        (PlaybackState::Playing, None) | (PlaybackState::NoFolder, _) => {
+            format!("Media Player: {folder}")
+        }
     }
 }
 
@@ -314,6 +382,7 @@ mod tests {
                 crate::tts::engines::ELEVENLABS.to_string(),
                 HashMap::from([("21m00Tcm4TlvDq8ikWAM".to_string(), "Rachel".to_string())]),
             )]),
+            media: HashMap::new(),
         }
     }
 
@@ -420,6 +489,105 @@ mod tests {
             ),
             "Sound Events"
         );
+    }
+
+    fn media_player(folder: &str) -> SourceConfig {
+        source(SourceKindConfig::MediaPlayer(
+            crate::config::MediaPlayerSourceConfig {
+                folder: folder.to_string(),
+                ..Default::default()
+            },
+        ))
+    }
+
+    fn playing(track: &str) -> crate::media::player::Status {
+        crate::media::player::Status {
+            state: crate::media::player::PlaybackState::Playing,
+            track: Some(track.to_string()),
+            ..Default::default()
+        }
+    }
+
+    /// The strip name must be the folder and never the track: it is spoken
+    /// again whenever it changes, and a track lasts three minutes.
+    #[test]
+    fn a_media_player_strip_is_named_after_its_folder() {
+        let src = media_player(r"D:\music\Jazz");
+        let mut ctx = ctx();
+        ctx.media.insert(src.name.clone(), playing("So What"));
+        assert_eq!(strip_label(&src, &ctx), "Media Player (Jazz)");
+    }
+
+    #[test]
+    fn the_sources_list_says_what_is_playing() {
+        let src = media_player(r"D:\music\Jazz");
+        let mut ctx = ctx();
+        ctx.media.insert(src.name.clone(), playing("So What"));
+        assert_eq!(list_label(&src, &ctx), "Media Player: Jazz, playing So What");
+    }
+
+    #[test]
+    fn a_paused_media_player_says_so_and_keeps_its_track() {
+        let src = media_player(r"D:\music\Jazz");
+        let mut ctx = ctx();
+        ctx.media.insert(
+            src.name.clone(),
+            crate::media::player::Status {
+                state: crate::media::player::PlaybackState::Paused,
+                track: Some("So What".to_string()),
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            list_label(&src, &ctx),
+            "Media Player: Jazz, paused on So What"
+        );
+    }
+
+    /// A media player in a scene that is not active has no worker, so there is
+    /// nothing to report about playback — and it must not claim there is.
+    #[test]
+    fn a_media_player_in_another_scene_reports_only_its_folder() {
+        assert_eq!(
+            list_label(&media_player(r"D:\music\Jazz"), &ctx()),
+            "Media Player: Jazz"
+        );
+    }
+
+    #[test]
+    fn a_media_player_with_no_folder_says_it_needs_one() {
+        assert_eq!(
+            list_label(&media_player("  "), &ctx()),
+            "Media Player: no folder set"
+        );
+        assert_eq!(strip_label(&media_player(""), &ctx()), "Media Player");
+    }
+
+    #[test]
+    fn a_folder_with_nothing_playable_in_it_is_not_silent_about_it() {
+        let src = media_player(r"D:\music\Jazz\");
+        let mut ctx = ctx();
+        ctx.media.insert(
+            src.name.clone(),
+            crate::media::player::Status {
+                state: crate::media::player::PlaybackState::NoFiles,
+                track: None,
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            list_label(&src, &ctx),
+            "Media Player: Jazz has no audio files Pubsplash can play"
+        );
+    }
+
+    #[test]
+    fn a_folder_name_is_its_last_component_however_it_is_written() {
+        assert_eq!(folder_name(r"D:\music\Jazz"), Some("Jazz"));
+        assert_eq!(folder_name(r"D:\music\Jazz\"), Some("Jazz"));
+        assert_eq!(folder_name("D:/music/Jazz"), Some("Jazz"));
+        assert_eq!(folder_name(r"D:\"), Some("D:"));
+        assert_eq!(folder_name("   "), None);
     }
 
     #[test]

--- a/src/ui/home.rs
+++ b/src/ui/home.rs
@@ -2,7 +2,9 @@
 
 use super::slider_uia;
 use super::{
-    App, ID_MIXER_BOOST, ID_MIXER_MONITOR, Monitors, StreamState, WXK_DOWN, WXK_END, WXK_HOME,
+    App, ID_MIXER_BOOST, ID_MIXER_MEDIA_NEXT, ID_MIXER_MEDIA_OPEN, ID_MIXER_MEDIA_PLAY,
+    ID_MIXER_MONITOR, Monitors,
+    StreamState, WXK_DOWN, WXK_END, WXK_HOME,
     WXK_LEFT, WXK_PAGEDOWN, WXK_PAGEUP, WXK_RIGHT, WXK_UP,
 };
 use crate::audio::EngineCommand;
@@ -188,6 +190,9 @@ pub fn switch_to_scene_named(app: &Rc<App>, name: &str) {
     // The new scene's sources are different strips at the same positions.
     app.clear_source_monitors();
     app.sync_engine_sources();
+    // The old scene's media players have no ring to feed now, and the new
+    // scene's have one waiting.
+    sync_media_players(app);
     rebuild_mixer(app);
     refresh_scene_list(app);
     // Nothing else says which scene is live when the switch came from a
@@ -513,6 +518,26 @@ pub fn rebuild_mixer(app: &Rc<App>) {
     // Strip names are derived from what each source points at (device, running
     // application, voice) rather than from `SourceConfig.name`, which is only
     // ever the kind's display name — see `crate::source_name`.
+    // The identity name of every source that is a media player, by strip index,
+    // so those strips can carry transport in their context menu. `None` for
+    // every other kind.
+    let media_names: Vec<Option<String>> = {
+        let config = app.config.borrow();
+        config
+            .scenes
+            .active_scene()
+            .map(|scene| {
+                scene
+                    .sources
+                    .iter()
+                    .map(|source| match source.kind {
+                        crate::config::SourceKindConfig::MediaPlayer(_) => Some(source.name.clone()),
+                        _ => None,
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    };
     let ((master_volume, master_muted, master_boost), sources, buses) = {
         let config = app.config.borrow();
         let ctx = app.name_context(
@@ -559,6 +584,7 @@ pub fn rebuild_mixer(app: &Rc<App>) {
         master_boost,
         StripTarget::Master,
         None,
+        None,
     );
 
     for (index, (name, volume, muted, boost)) in sources.iter().enumerate() {
@@ -572,6 +598,7 @@ pub fn rebuild_mixer(app: &Rc<App>) {
             *boost,
             StripTarget::Source(index),
             Some(index),
+            media_names.get(index).cloned().flatten(),
         );
     }
     for (index, (name, volume, muted, boost)) in buses.iter().enumerate() {
@@ -584,6 +611,7 @@ pub fn rebuild_mixer(app: &Rc<App>) {
             *muted,
             *boost,
             StripTarget::Bus(index),
+            None,
             None,
         );
     }
@@ -711,6 +739,9 @@ fn add_strip(
     boost: bool,
     target: StripTarget,
     source_index: Option<usize>,
+    // `Some(identity name)` when this strip is a Media Player, which is what
+    // puts play/pause and next track in its context menu.
+    media_source: Option<String>,
 ) {
     let row = BoxSizer::builder(Orientation::Horizontal).build();
     let label = StaticText::builder(parent).build();
@@ -774,6 +805,32 @@ fn add_strip(
         SizerFlag::AlignCenterVertical | SizerFlag::All,
         4,
     );
+    // A media player's strip carries the one transport control that cannot be
+    // done blind: picking a file. Play, pause and skip are keybindings and menu
+    // items because they are pressed mid-broadcast from wherever the user
+    // happens to be, but choosing a track means a file dialog either way, so it
+    // may as well have a button — and a button is what makes the feature
+    // findable at all by somebody who has not been through the Keybinds tab.
+    //
+    // No mnemonic: this is the Home tab, where a mnemonic on a per-strip control
+    // would collide with every other strip's copy of it.
+    if let Some(source) = &media_source {
+        let open = Button::builder(parent).with_label("Open file...").build();
+        // Named after the strip, like everything else on it — the identity name
+        // the click carries is a routing key and not what the user calls this.
+        super::set_accessible_name(&open, &format!("Open a file to play on {}", name.borrow()));
+        super::help::tag(
+            &open,
+            "tab.home.mixer.strip.openFile",
+            "Mixer strip open file button",
+        );
+        {
+            let app = app.clone();
+            let source = source.clone();
+            open.on_click(move |_| super::media_open_file(&app, &source));
+        }
+        row.add(&open, 0, SizerFlag::AlignCenterVertical | SizerFlag::All, 4);
+    }
     sizer.add_sizer(&row, 0, SizerFlag::Expand, 0);
 
     // Volume changes.
@@ -867,10 +924,11 @@ fn add_strip(
     {
         let app = app.clone();
         let slider_for_menu = slider;
+        let media_source = media_source.clone();
         slider.bind_internal(EventType::CONTEXT_MENU, move |_| {
             let boost = boost_of(&app, target);
             let monitor = monitor_of(&app, target);
-            let mut menu = Menu::builder()
+            let mut builder = Menu::builder()
                 .append_check_item(
                     ID_MIXER_BOOST,
                     "Enable volume boost",
@@ -880,8 +938,34 @@ fn add_strip(
                     ID_MIXER_MONITOR,
                     "&Monitor this strip",
                     "Play this strip through your speakers or headphones",
-                )
-                .build();
+                );
+            // A media player's transport lives here as well as on a keybinding,
+            // so it is reachable without one — and it is read from the player
+            // every time the menu opens, so the item says what pressing it will
+            // do rather than what it did last time.
+            if let Some(name) = &media_source {
+                let paused = app.media.status(name).is_some_and(|status| {
+                    status.state == crate::media::player::PlaybackState::Paused
+                });
+                builder = builder
+                    .append_separator()
+                    .append_item(
+                        ID_MIXER_MEDIA_PLAY,
+                        if paused { "&Play" } else { "&Pause" },
+                        "Start or stop this media player",
+                    )
+                    .append_item(
+                        ID_MIXER_MEDIA_NEXT,
+                        "&Next track",
+                        "Skip to the next track in the folder",
+                    )
+                    .append_item(
+                        ID_MIXER_MEDIA_OPEN,
+                        "&Open file...",
+                        "Play a file of your choosing, then carry on with the folder",
+                    );
+            }
+            let mut menu = builder.build();
             menu.check_item(ID_MIXER_BOOST, boost);
             menu.check_item(ID_MIXER_MONITOR, monitor);
             // Anchor to the slider rather than the mouse so the keyboard paths
@@ -919,6 +1003,32 @@ fn add_strip(
         slider.bind_with_id_internal(EventType::MENU, ID_MIXER_MONITOR, move |_| {
             toggle_monitor(&app, target, &strip_for_menu_monitor);
         });
+    }
+
+    // Media transport, from the same popup. Both go through
+    // `super::media_transport`, which is also what the keybindings call, so the
+    // spoken feedback is identical either way.
+    if let Some(name) = media_source {
+        {
+            let app = app.clone();
+            let name = name.clone();
+            slider.bind_with_id_internal(EventType::MENU, ID_MIXER_MEDIA_PLAY, move |_| {
+                super::media_transport(&app, &name, crate::media::player::Command::PlayPause);
+            });
+        }
+        {
+            let app = app.clone();
+            let name = name.clone();
+            slider.bind_with_id_internal(EventType::MENU, ID_MIXER_MEDIA_NEXT, move |_| {
+                super::media_transport(&app, &name, crate::media::player::Command::Next);
+            });
+        }
+        {
+            let app = app.clone();
+            slider.bind_with_id_internal(EventType::MENU, ID_MIXER_MEDIA_OPEN, move |_| {
+                super::media_open_file(&app, &name);
+            });
+        }
     }
 
     // Mute toggling; unmute restores the last volume (kept in config). The
@@ -1148,8 +1258,9 @@ pub fn on_sources_changed(app: &Rc<App>, previous_sources: Option<&[SourceConfig
     app.sync_engine_sources();
     // Beside `sync_engine_sources`, because that is where `ExternalFeeds` gains
     // and loses its rings: a cue worker for a source that just left the scene
-    // has nothing left to feed.
+    // has nothing left to feed, and a media player for one has nowhere to play.
     app.cues.retain(&active_source_names(app));
+    sync_media_players(app);
     rebuild_mixer(app);
     refresh_scene_list(app);
 }
@@ -1161,6 +1272,24 @@ fn active_source_names(app: &Rc<App>) -> std::collections::HashSet<String> {
         Some(scene) => scene.sources.iter().map(|s| s.name.clone()).collect(),
         None => std::collections::HashSet::new(),
     }
+}
+
+/// Starts a worker for every media player in the active scene and retires the
+/// rest.
+///
+/// Called wherever the active scene's source list can have changed — beside
+/// `sync_engine_sources`, which is what installs and removes the rings these
+/// workers feed. The sources are copied out first because `apply` starts and
+/// joins threads, and nothing that waits should be holding the config borrow.
+pub fn sync_media_players(app: &Rc<App>) {
+    let sources = {
+        let config = app.config.borrow();
+        match config.scenes.active_scene() {
+            Some(scene) => scene.sources.clone(),
+            None => Vec::new(),
+        }
+    };
+    app.media.apply(&sources, &app.engine.external_feeds);
 }
 
 #[cfg(test)]

--- a/src/ui/keybinds.rs
+++ b/src/ui/keybinds.rs
@@ -355,6 +355,13 @@ fn run(app: &Rc<App>, action: &BindAction) {
                 home::toggle_mute_target(app, target);
             }
         }
+        BindAction::ToggleMediaPlayback { source } => {
+            super::media_transport(app, source, crate::media::player::Command::PlayPause);
+        }
+        BindAction::NextTrack { source } => {
+            super::media_transport(app, source, crate::media::player::Command::Next);
+        }
+        BindAction::OpenTrack { source } => super::media_open_file(app, source),
     }
 }
 

--- a/src/ui/keybinds_ui.rs
+++ b/src/ui/keybinds_ui.rs
@@ -176,9 +176,19 @@ pub fn build_tab(app: &Rc<App>, dialog: &Dialog, panel: &Panel) {
         let dialog = *dialog;
         let refresh = refresh.clone();
         reset.on_click(move |_| {
+            // The Open-file default names a source, so it is not in
+            // `KeybindsConfig::default()` and has to be restored separately —
+            // and only promised here when there is a media player to give it to.
+            let media = crate::keybind::Targets::from_config(&app.config.borrow())
+                .media_sources
+                .first()
+                .cloned();
             let confirm = MessageDialog::builder(
                 &dialog,
-                "Discard every keybinding and restore the defaults, F9 for streaming and F10 for recording?",
+                match &media {
+                    Some(_) => "Discard every keybinding and restore the defaults: F9 for streaming, F10 for recording, and CONTROL plus O to open a file on your first media player?",
+                    None => "Discard every keybinding and restore the defaults, F9 for streaming and F10 for recording?",
+                },
                 "Reset to defaults",
             )
             .with_style(MessageDialogStyle::YesNo | MessageDialogStyle::IconQuestion)
@@ -186,7 +196,13 @@ pub fn build_tab(app: &Rc<App>, dialog: &Dialog, panel: &Panel) {
             if confirm.show_modal() != ID_YES {
                 return;
             }
-            app.config.borrow_mut().keybinds = crate::keybind::KeybindsConfig::default();
+            {
+                let mut config = app.config.borrow_mut();
+                config.keybinds = crate::keybind::KeybindsConfig::default();
+                if let Some(name) = &media {
+                    config.keybinds.seed_media_defaults(name);
+                }
+            }
             app.save_config();
             super::keybinds::reload(&app.config.borrow());
             refresh(None);
@@ -245,7 +261,7 @@ fn edit_dialog(app: &Rc<App>, parent: &Dialog, initial: Option<BindAction>) -> O
     super::help::tag(
         &specifier_choice,
         "dialog.keybind.specifier",
-        "Binding scene, source or bus choice",
+        "Binding scene, source, bus or media player choice",
     );
 
     let shortcut_label = StaticText::builder(&panel).with_label("Shortcut").build();

--- a/src/ui/media.rs
+++ b/src/ui/media.rs
@@ -1,0 +1,211 @@
+//! The live media players: one worker per Media Player source in the active
+//! scene.
+//!
+//! Same shape and the same reasons as [`super::cue_feed`] — a worker is keyed by
+//! `SourceConfig.name`, the identity key `ExternalFeeds` is routed by, and is
+//! started and retired from `home::on_sources_changed`, beside
+//! `sync_engine_sources`, because that is the moment the rings appear and
+//! disappear. Only the active scene's players run: a media player in a scene
+//! nobody is on has no ring to feed, and would be reading a folder off disk for
+//! nothing.
+//!
+//! Playback state is session state, like monitoring. A player starts playing
+//! when its scene becomes active and forgets it was paused when the scene
+//! changes, which is the same rule the mixer's monitor toggles follow.
+//!
+//! Everything here runs on the UI thread except the worker bodies, which never
+//! touch `App`: they report what they are doing through their own `Status` and
+//! bump a shared generation counter, and the pump notices the counter has moved
+//! and re-derives the labels. Same pattern as `tts::usage`.
+
+use crate::audio::ExternalFeeds;
+use crate::config::{SourceConfig, SourceKindConfig};
+use crate::media::player::{Command, Player, Status};
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+#[derive(Default)]
+pub struct MediaPlayers {
+    players: RefCell<HashMap<String, Player>>,
+    /// Bumped by any worker whose status changes; polled by the pump.
+    generation: Arc<AtomicU64>,
+}
+
+impl MediaPlayers {
+    /// How many times any player's status has changed. The pump compares this
+    /// with what it last saw rather than being sent an event, because the
+    /// writers are worker threads and the readers are labels.
+    pub fn generation(&self) -> u64 {
+        self.generation.load(Ordering::Relaxed)
+    }
+
+    /// Brings the running players in line with `sources`: starts one for every
+    /// Media Player in the active scene, retires the ones whose source has gone,
+    /// and tells a surviving one when its folder or shuffle setting changed.
+    ///
+    /// Restarting a player whose settings did not move would restart its music,
+    /// and this is called on every scene edit — including edits to entirely
+    /// different sources.
+    pub fn apply(&self, sources: &[SourceConfig], feeds: &ExternalFeeds) {
+        let wanted: Vec<(String, String, bool)> = sources
+            .iter()
+            .filter_map(|source| match &source.kind {
+                SourceKindConfig::MediaPlayer(media) => Some((
+                    source.name.clone(),
+                    media.folder.clone(),
+                    media.shuffle,
+                )),
+                _ => None,
+            })
+            .collect();
+
+        let retired: Vec<Player> = {
+            let mut players = self.players.borrow_mut();
+            let gone: Vec<String> = players
+                .keys()
+                .filter(|name| !wanted.iter().any(|(wanted, ..)| wanted == *name))
+                .cloned()
+                .collect();
+            let retired = gone.iter().filter_map(|name| players.remove(name)).collect();
+
+            for (name, folder, shuffle) in wanted {
+                match players.get_mut(&name) {
+                    Some(player) => {
+                        if player.folder != folder || player.shuffle != shuffle {
+                            player.folder = folder.clone();
+                            player.shuffle = shuffle;
+                            player.send(Command::Reload { folder, shuffle });
+                        }
+                    }
+                    None => {
+                        let player = Player::start(
+                            name.clone(),
+                            feeds.clone(),
+                            folder,
+                            shuffle,
+                            self.generation.clone(),
+                        );
+                        players.insert(name, player);
+                    }
+                }
+            }
+            retired
+        };
+        // Stopped outside the borrow: `stop` joins a thread, and nothing that
+        // waits should be holding a `RefCell` the rest of the UI reaches for.
+        for player in retired {
+            player.stop();
+        }
+    }
+
+    /// Every running player's state, keyed by source name, for the labels.
+    pub fn statuses(&self) -> HashMap<String, Status> {
+        self.players
+            .borrow()
+            .iter()
+            .map(|(name, player)| (name.clone(), player.status()))
+            .collect()
+    }
+
+    pub fn status(&self, source_name: &str) -> Option<Status> {
+        self.players.borrow().get(source_name).map(Player::status)
+    }
+
+    /// Sends a transport command to one player. Nothing happens if that source
+    /// is not a media player in the active scene — a keybinding names a source
+    /// that may live in another scene entirely.
+    pub fn send(&self, source_name: &str, command: Command) -> bool {
+        match self.players.borrow().get(source_name) {
+            Some(player) => {
+                player.send(command);
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Retires every player. Used at shutdown.
+    pub fn stop_all(&self) {
+        let retired: Vec<Player> = self.players.borrow_mut().drain().map(|(_, p)| p).collect();
+        for player in retired {
+            player.stop();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::MediaPlayerSourceConfig;
+
+    fn media_source(name: &str, folder: &str) -> SourceConfig {
+        SourceConfig {
+            name: name.to_string(),
+            kind: SourceKindConfig::MediaPlayer(MediaPlayerSourceConfig {
+                folder: folder.to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn a_media_source_gets_a_player_and_loses_it_with_the_scene() {
+        let feeds = ExternalFeeds::default();
+        let players = MediaPlayers::default();
+
+        players.apply(&[media_source("Media Player", "")], &feeds);
+        assert_eq!(players.players.borrow().len(), 1);
+
+        // A scene with no media player in it retires the worker.
+        players.apply(&[], &feeds);
+        assert!(players.players.borrow().is_empty());
+    }
+
+    /// The property `apply` exists for: an edit to some other source must not
+    /// restart the music.
+    #[test]
+    fn an_unrelated_edit_leaves_the_player_alone() {
+        let feeds = ExternalFeeds::default();
+        let players = MediaPlayers::default();
+        players.apply(&[media_source("Media Player", "")], &feeds);
+        let first = players.players.borrow()["Media Player"].thread_id();
+
+        players.apply(
+            &[
+                media_source("Media Player", ""),
+                SourceConfig {
+                    name: "Microphone".to_string(),
+                    ..Default::default()
+                },
+            ],
+            &feeds,
+        );
+
+        assert_eq!(
+            players.players.borrow()["Media Player"].thread_id(),
+            first,
+            "the same worker is still playing"
+        );
+        players.stop_all();
+    }
+
+    #[test]
+    fn a_folder_change_reaches_the_running_player() {
+        let feeds = ExternalFeeds::default();
+        let players = MediaPlayers::default();
+        players.apply(&[media_source("Media Player", "")], &feeds);
+        let first = players.players.borrow()["Media Player"].thread_id();
+
+        players.apply(&[media_source("Media Player", r"C:\music")], &feeds);
+
+        let borrowed = players.players.borrow();
+        let player = &borrowed["Media Player"];
+        assert_eq!(player.thread_id(), first, "reloaded, not restarted");
+        assert_eq!(player.folder, r"C:\music");
+        drop(borrowed);
+        players.stop_all();
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -20,6 +20,7 @@ mod logging_ui;
 mod mastodon_post;
 mod mastodon_prefs;
 mod mastodon_templates;
+mod media;
 mod native_acc;
 mod panes;
 mod preferences;
@@ -78,6 +79,12 @@ const ID_MENU_GOTO_DATA_DIR: i32 = 2402;
 pub const ID_MIXER_BOOST: i32 = 2201;
 /// Command id of the "Monitor this strip" item in the same menu.
 pub const ID_MIXER_MONITOR: i32 = 2202;
+/// Command ids of the media player items in the same menu, added only to the
+/// strips that have a player behind them. Transport has to be reachable while a
+/// broadcast is running, and this is where the user already is.
+pub const ID_MIXER_MEDIA_PLAY: i32 = 2203;
+pub const ID_MIXER_MEDIA_NEXT: i32 = 2204;
+pub const ID_MIXER_MEDIA_OPEN: i32 = 2205;
 /// Id worn by every dialog's confirm button, so that ENTER can reach it. See
 /// `ok_button`, which is the only thing that should ever use it — and which
 /// documents why it is this private id rather than `ID_OK`.
@@ -243,11 +250,21 @@ pub struct Runtime {
     /// happens on worker threads, so the pump watches this rather than being
     /// told, exactly as it does for the catalog above.
     pub usage_generation: u64,
+    /// The `App::media` generation the source labels were last built from. A
+    /// media player moving to the next track is the same shape of problem: a
+    /// worker thread changed what a label should say.
+    pub media_generation: u64,
     /// Which mixer strips are being monitored through the local playback
     /// device. Deliberately not persisted — see [`Monitors`].
     pub monitors: Monitors,
     /// What `refresh_stream_ui` last wrote to the stream/record controls.
     pub shown: ShownStreamUi,
+    /// The answer to the last `MeasureDuckTrigger`, waiting to be collected by
+    /// whoever asked for it — the Calibrate button in the Media Player source
+    /// dialog. Parked here rather than delivered because the engine's events
+    /// have exactly one reader, the pump, and the dialog that wants this is a
+    /// modal the pump keeps ticking underneath (see `scenes::calibrate_duck`).
+    pub duck_calibration: Option<f32>,
     /// When the next still-streaming Mastodon post is due, or `None` when none
     /// is. A deadline rather than a tick count, so it survives ticks missed
     /// under a modal dialog and a stream that started mid-interval.
@@ -522,8 +539,11 @@ impl Default for Runtime {
             // Nothing has spoken yet, so this is 0 and the first pump tick has
             // nothing to redraw.
             usage_generation: crate::tts::usage::generation(),
+            // No media player is running before the first scene is applied.
+            media_generation: 0,
             monitors: Monitors::default(),
             shown: ShownStreamUi::default(),
+            duck_calibration: None,
             next_announcement: None,
             last_stream: None,
         }
@@ -703,6 +723,8 @@ pub struct App {
     /// One worker per sound-event source, feeding its cues into the mixer. See
     /// [`cue_feed`] for why this is not a thread per cue.
     pub cues: cue_feed::CueFeeds,
+    /// One worker per Media Player source in the active scene. See [`media`].
+    pub media: media::MediaPlayers,
     /// Open native plugin editor windows.
     pub open_editors: RefCell<Vec<fx_editor::EditorWindow>>,
     /// Set once the frame is closing. The pump timer keeps firing during the
@@ -930,6 +952,129 @@ fn report_speech_problems(app: &Rc<App>) {
     }
 }
 
+/// Drives one media player's transport and says what happened.
+///
+/// Every route to play, pause and skip comes through here — the keybindings and
+/// the mixer strip's context menu — so the spoken feedback is the same whichever
+/// one the user took. Announced rather than shown: these are pressed while the
+/// user is somewhere else entirely, often mid-broadcast, and the answer has to
+/// reach them without moving focus.
+pub(crate) fn media_transport(
+    app: &Rc<App>,
+    source_name: &str,
+    command: crate::media::player::Command,
+) {
+    use crate::media::player::{Command, PlaybackState};
+    let Some(status) = app.media.status(source_name) else {
+        // The binding names a source by identity, and that source may live in a
+        // scene that is not the active one — where there is no player at all.
+        help::announce(&format!(
+            "There is no media player called {source_name} in this scene"
+        ));
+        return;
+    };
+    let label = media_label(app, source_name);
+    let spoken = match (&command, &status.state) {
+        (Command::PlayPause, PlaybackState::Paused) => match &status.track {
+            Some(track) => format!("{label}, playing {track}"),
+            None => format!("{label}, playing"),
+        },
+        (Command::PlayPause, _) => format!("{label}, paused"),
+        // The track being skipped *to*, which the player publishes for exactly
+        // this — "next track" told the user only what they had just pressed.
+        // `None` is a folder with nothing playable in it, where there is no
+        // answer to give and the label already says so.
+        (Command::Next, _) => match &status.next {
+            Some(next) => format!("{label}, playing {next}"),
+            None => format!("{label}, next track"),
+        },
+        (Command::PlayFile(path), _) => {
+            format!("{label}, playing {}", crate::media::track_title(path))
+        }
+        // Settings edits do not come through here; `media::apply` sends them.
+        (Command::Reload { .. }, _) => return,
+    };
+    app.media.send(source_name, command);
+    help::announce(&spoken);
+}
+
+/// Asks for a file and plays it on one media player, in place of whatever it is
+/// on now.
+///
+/// The picker is a modal, which everything else in `media_transport` is
+/// deliberately not — but this one answers a deliberate press and cannot arrive
+/// on its own, which is the test that decides between a dialog and an
+/// announcement. Every filter is built from the decoder's own list, so the
+/// dialog cannot offer a file the player would then fail to play.
+pub(crate) fn media_open_file(app: &Rc<App>, source_name: &str) {
+    if app.media.status(source_name).is_none() {
+        help::announce(&format!(
+            "There is no media player called {source_name} in this scene"
+        ));
+        return;
+    }
+    let Some(frame) = app.widgets(|w| w.frame) else {
+        return;
+    };
+    let patterns = crate::media::SUPPORTED_EXTENSIONS
+        .iter()
+        .map(|e| format!("*.{e}"))
+        .collect::<Vec<_>>()
+        .join(";");
+    let dialog = FileDialog::builder(&frame)
+        .with_message("Choose a file to play")
+        // The folder the source plays is where the user is most likely to be
+        // looking, and it costs nothing when they are not.
+        .with_default_dir(&media_folder(app, source_name))
+        .with_wildcard(&format!("Audio files ({patterns})|{patterns}|All files (*.*)|*.*"))
+        .with_style(FileDialogStyle::Open | FileDialogStyle::FileMustExist)
+        .build();
+    let chosen = if dialog.show_modal() == ID_OK {
+        dialog.get_path()
+    } else {
+        None
+    };
+    let Some(path) = chosen else {
+        return;
+    };
+    media_transport(
+        app,
+        source_name,
+        crate::media::player::Command::PlayFile(std::path::PathBuf::from(path)),
+    );
+}
+
+/// The folder one media player source is configured with, for the file picker
+/// to open in. Empty when the source has none, which wx reads as "wherever you
+/// were last".
+fn media_folder(app: &Rc<App>, source_name: &str) -> String {
+    let config = app.config.borrow();
+    config
+        .scenes
+        .active_scene()
+        .and_then(|scene| scene.sources.iter().find(|s| s.name == source_name))
+        .and_then(|source| match &source.kind {
+            SourceKindConfig::MediaPlayer(media) => Some(media.folder.clone()),
+            _ => None,
+        })
+        .unwrap_or_default()
+}
+
+/// What to call a media player out loud: the same name its mixer strip has.
+///
+/// Built against an empty [`NameContext`] on purpose — a media player's name
+/// comes from its folder and nothing else, and the full context enumerates
+/// capture devices, which is not something to do on a keypress.
+fn media_label(app: &Rc<App>, source_name: &str) -> String {
+    let config = app.config.borrow();
+    config
+        .scenes
+        .active_scene()
+        .and_then(|scene| scene.sources.iter().find(|s| s.name == source_name))
+        .map(|source| crate::source_name::strip_label(source, &NameContext::default()))
+        .unwrap_or_else(|| source_name.to_string())
+}
+
 /// Whether a source's audio should reach the listeners.
 ///
 /// Only TTS sources can answer no, and it is exactly what "Send speech to the
@@ -1091,8 +1236,9 @@ impl App {
     /// sources explicitly because the Sources list shows whichever scene is
     /// selected, which is not always the active one.
     pub fn name_context(&self, sources: &[crate::config::SourceConfig]) -> NameContext {
+        let media = self.media.statuses();
         let run = self.run.borrow();
-        NameContext::build(sources, run.apps.clone(), run.failing.clone())
+        NameContext::build(sources, run.apps.clone(), run.failing.clone(), media)
     }
 
     /// Re-enumerates the processes behind every scene's Application sources —
@@ -1318,6 +1464,20 @@ impl App {
                 // Speech is for the broadcaster first, so a TTS strip is always
                 // played out of the local device — see `SourceSpec::local`.
                 local: matches!(&s.kind, SourceKindConfig::Tts(_)),
+                // Only a media player ducks, and only when it is asked to. The
+                // rest of the mixer is what it ducks *for*, which is why every
+                // other source is a trigger — a microphone, a game, a chat
+                // message being read out.
+                duck: match &s.kind {
+                    SourceKindConfig::MediaPlayer(media) if media.duck => {
+                        Some(crate::audio::DuckSpec {
+                            percent: media.duck_percent,
+                            threshold_db: media.duck_threshold_db,
+                        })
+                    }
+                    _ => None,
+                },
+                duck_trigger: !matches!(&s.kind, SourceKindConfig::MediaPlayer(_)),
                 to_master: s.to_master && tts_reaches_the_stream(s),
                 // Sends go too when speech is off the stream. A bus mixes into
                 // master unconditionally, so leaving them would have put the
@@ -1355,9 +1515,9 @@ impl App {
                             }
                         }
                     }
-                    SourceKindConfig::Tts(_) | SourceKindConfig::SoundEvents(_) => {
-                        FeedKind::External
-                    }
+                    SourceKindConfig::Tts(_)
+                    | SourceKindConfig::SoundEvents(_)
+                    | SourceKindConfig::MediaPlayer(_) => FeedKind::External,
                 },
             })
             .collect();
@@ -1927,6 +2087,9 @@ pub fn build(app: Rc<App>) {
     // Buses before sources: sources reference buses by index.
     fx::sync_engine_buses(&app);
     app.sync_engine_sources();
+    // The active scene's media players start playing here, the same as its
+    // microphones start capturing.
+    home::sync_media_players(&app);
 
     if !failures.is_empty() {
         // Two different problems with two different answers: install the
@@ -2000,8 +2163,12 @@ pub fn build(app: Rc<App>) {
             // main frame goes away.
             fx_editor::close_all(&app);
             // Cue workers hold an `ExternalFeeds` clone and would otherwise sit
-            // on an empty queue through the whole shutdown cue.
+            // on an empty queue through the whole shutdown cue. Media players
+            // go for a stronger reason: theirs is not an idle thread but one
+            // decoding a file, and it would keep playing into the mixer for the
+            // whole of the shutdown sound.
             app.cues.stop_all();
+            app.media.stop_all();
             // Vanish immediately: the user asked to exit, so the app should
             // look gone while the cue finishes in the background.
             frame_for_close.show(false);
@@ -2786,6 +2953,10 @@ fn pump_events(app: &Rc<App>) {
             crate::audio::EngineEvent::BusesApplied => {
                 app.engine.reclaim_retired_chains();
             }
+            // Parked for the dialog that asked; see `Runtime::duck_calibration`.
+            crate::audio::EngineEvent::DuckTriggerMeasured { peak } => {
+                app.run.borrow_mut().duck_calibration = Some(peak);
+            }
         }
     }
     // Instances the UI took out of a chain but did not release, for the same
@@ -2804,6 +2975,18 @@ fn pump_events(app: &Rc<App>) {
         let mut run = app.run.borrow_mut();
         if run.tts_catalog_generation != generation {
             run.tts_catalog_generation = generation;
+            labels_dirty = true;
+        }
+    }
+
+    // A media player moved to another track, or was paused or resumed. The
+    // Sources list says what each one is playing, so the label is stale; the
+    // counter is how a worker thread reports that without touching `App`.
+    {
+        let generation = app.media.generation();
+        let mut run = app.run.borrow_mut();
+        if run.media_generation != generation {
+            run.media_generation = generation;
             labels_dirty = true;
         }
     }

--- a/src/ui/scenes.rs
+++ b/src/ui/scenes.rs
@@ -4,10 +4,11 @@
 use super::home::on_sources_changed;
 use super::slider_uia::SliderAnnouncer;
 use super::{App, WXK_DELETE, WXK_DOWN, WXK_UP, show_error};
+use crate::audio::mixer;
 use crate::config::{
-    AzureTtsSettings, ElevenLabsTtsSettings, GoogleTtsSettings, GttsTtsSettings, OpenAiTtsSettings,
-    PollyTtsSettings, SoundEventsSourceConfig, SourceConfig, SourceKindConfig, TtsEngineProfile,
-    TtsEngineSettings, TtsSourceConfig,
+    AzureTtsSettings, ElevenLabsTtsSettings, GoogleTtsSettings, GttsTtsSettings,
+    MediaPlayerSourceConfig, OpenAiTtsSettings, PollyTtsSettings, SoundEventsSourceConfig,
+    SourceConfig, SourceKindConfig, TtsEngineProfile, TtsEngineSettings, TtsSourceConfig,
 };
 use crate::soundpack::StreamEvent;
 use crate::state::{ListEdit, move_down, move_up};
@@ -466,6 +467,7 @@ fn add_source(app: &Rc<App>) {
         "Application",
         "Text-to-Speech",
         "Sound Events",
+        "Media Player",
     ];
     let dialog =
         SingleChoiceDialog::builder(&frame, "What kind of source?", "Add source", &types).build();
@@ -481,6 +483,7 @@ fn add_source(app: &Rc<App>) {
         },
         3 => SourceKindConfig::Tts(TtsSourceConfig::default()),
         4 => SourceKindConfig::SoundEvents(SoundEventsSourceConfig::default()),
+        5 => SourceKindConfig::MediaPlayer(MediaPlayerSourceConfig::default()),
         _ => return,
     };
 
@@ -492,12 +495,20 @@ fn add_source(app: &Rc<App>) {
             return;
         };
         let name = unique_source_name(&scene.sources, kind.type_display_name());
+        let media = matches!(kind, SourceKindConfig::MediaPlayer(_));
         scene.sources.push(SourceConfig {
-            name,
+            name: name.clone(),
             kind,
             ..Default::default()
         });
-        scene.sources.len() - 1
+        let index = scene.sources.len() - 1;
+        // Open file is worth a key out of the box, and the binding names a
+        // source, so this is the only moment it can be given one. The hook's
+        // snapshot is re-read below, once the save has happened.
+        if media && config.keybinds.seed_media_defaults(&name) {
+            super::keybinds::reload(&config);
+        }
+        index
     };
     after_source_edit(app, previous_sources);
     app.widgets(|w| w.sources_list.set_selection(new_index as u32, true));
@@ -544,6 +555,9 @@ fn edit_source(app: &Rc<App>, list: &ListBox) {
         }
         SourceKindConfig::SoundEvents(settings) => {
             edit_sound_events(app, scene_index, index, settings)
+        }
+        SourceKindConfig::MediaPlayer(settings) => {
+            edit_media_player(app, scene_index, index, settings)
         }
     }
 }
@@ -2485,6 +2499,300 @@ fn edit_sound_events(
         );
     }
     dialog.destroy();
+}
+
+/// The Media Player source dialog: which folder, in what order, and how far out
+/// of the way it gets when somebody talks.
+///
+/// There are no transport controls here. Play, pause and skip belong somewhere
+/// reachable while a broadcast is running — the strip's context menu and a
+/// keybinding — not behind a modal that has to be opened and dismissed.
+fn edit_media_player(
+    app: &Rc<App>,
+    scene_index: usize,
+    source_index: usize,
+    current: MediaPlayerSourceConfig,
+) {
+    let Some(frame) = app.widgets(|w| w.frame) else {
+        return;
+    };
+    let dialog = Dialog::builder(&frame, "Media Player source")
+        .with_style(DialogStyle::DefaultDialogStyle)
+        // Tall enough for the ducking group in full: two sliders, the calibrate
+        // button and the wrapped note under them.
+        .with_size(520, 540)
+        .build();
+    let panel = Panel::builder(&dialog).build();
+    let sizer = BoxSizer::builder(Orientation::Vertical).build();
+
+    let folder_label = StaticText::builder(&panel).with_label("&Folder").build();
+    let folder_input = TextCtrl::builder(&panel)
+        .with_value(&current.folder)
+        .build();
+    super::set_accessible_name(&folder_input, "Folder");
+    super::help::tag(
+        &folder_input,
+        "dialog.mediaPlayerSource.folder",
+        "Media player folder box",
+    );
+    let browse = Button::builder(&panel).with_label("&Browse...").build();
+
+    let shuffle = CheckBox::builder(&panel)
+        .with_label("&Shuffle the folder")
+        .build();
+    super::set_accessible_name(&shuffle, "Shuffle the folder");
+    super::help::tag(
+        &shuffle,
+        "dialog.mediaPlayerSource.shuffle",
+        "Shuffle checkbox",
+    );
+    shuffle.set_value(current.shuffle);
+
+    let duck = CheckBox::builder(&panel)
+        .with_label("&Turn the music down while other sources are playing")
+        .build();
+    super::set_accessible_name(
+        &duck,
+        "Turn the music down while other sources are playing",
+    );
+    super::help::tag(&duck, "dialog.mediaPlayerSource.duck", "Ducking checkbox");
+    duck.set_value(current.duck);
+
+    let duck_label = StaticText::builder(&panel)
+        .with_label("Turned-down &level")
+        .build();
+    let duck_slider = Slider::builder(&panel)
+        .with_value(current.duck_percent.min(100) as i32)
+        .with_min_value(0)
+        .with_max_value(100)
+        .build();
+    super::set_accessible_name(&duck_slider, "Turned-down level");
+    super::help::tag(
+        &duck_slider,
+        "dialog.mediaPlayerSource.duckLevel",
+        "Turned-down level slider",
+    );
+    let duck_announcer = wire_slider(&duck_slider, "Turned-down level", "%", 0, 100, 10);
+
+    // The threshold sits beside the level it belongs to, and the Calibrate
+    // button beside the threshold, because the number is the hard part: nobody
+    // knows what their own voice measures, and the answer is different for every
+    // microphone and every gain setting.
+    let threshold_label = StaticText::builder(&panel)
+        .with_label("Start turning down &at")
+        .build();
+    let threshold_slider = Slider::builder(&panel)
+        .with_value(mixer::clamp_threshold_db(current.duck_threshold_db))
+        .with_min_value(mixer::DUCK_THRESHOLD_DB_MIN)
+        .with_max_value(mixer::DUCK_THRESHOLD_DB_MAX)
+        .build();
+    super::set_accessible_name(&threshold_slider, "Start turning down at");
+    super::help::tag(
+        &threshold_slider,
+        "dialog.mediaPlayerSource.duckThreshold",
+        "Ducking threshold slider",
+    );
+    let threshold_announcer = wire_slider(
+        &threshold_slider,
+        "Start turning down at",
+        " dB",
+        mixer::DUCK_THRESHOLD_DB_MIN,
+        mixer::DUCK_THRESHOLD_DB_MAX,
+        5,
+    );
+    let calibrate = Button::builder(&panel)
+        .with_label("&Calibrate to my voice")
+        .build();
+    super::help::tag(
+        &calibrate,
+        "dialog.mediaPlayerSource.calibrate",
+        "Calibrate ducking threshold button",
+    );
+
+    // The question every broadcaster asks about this source, answered where
+    // they are asking it. Desktop Audio captures the system's other
+    // applications and deliberately excludes Pubsplash's own output, so the
+    // music cannot come back round that way; what it *can* do is reach an open
+    // microphone through the speakers.
+    let note = StaticText::builder(&panel)
+        .with_label(
+            "This music is mixed into the stream directly. A Desktop Audio source will not \
+             capture it a second time, because Desktop Audio leaves Pubsplash's own sound out. \
+             If you monitor this source, use headphones: a microphone in the same room will pick \
+             the music up and send it out twice, echoed.",
+        )
+        .build();
+    note.wrap(480);
+
+    let buttons = BoxSizer::builder(Orientation::Horizontal).build();
+    let ok = super::ok_button(&panel, "OK");
+    // `ID_CANCEL` is what wx maps Escape to; without it Escape does nothing.
+    let cancel = Button::builder(&panel)
+        .with_id(ID_CANCEL)
+        .with_label("Cancel")
+        .build();
+    buttons.add(&ok, 0, SizerFlag::All, 4);
+    buttons.add(&cancel, 0, SizerFlag::All, 4);
+
+    let folder_row = BoxSizer::builder(Orientation::Horizontal).build();
+    folder_row.add(&folder_input, 1, SizerFlag::Expand | SizerFlag::All, 4);
+    folder_row.add(&browse, 0, SizerFlag::All, 4);
+    sizer.add(&folder_label, 0, SizerFlag::All, 4);
+    sizer.add_sizer(&folder_row, 0, SizerFlag::Expand, 0);
+    sizer.add(&shuffle, 0, SizerFlag::All, 4);
+    sizer.add(&duck, 0, SizerFlag::All, 4);
+    sizer.add(&duck_label, 0, SizerFlag::All, 4);
+    sizer.add(&duck_slider, 0, SizerFlag::Expand | SizerFlag::All, 4);
+    sizer.add(&threshold_label, 0, SizerFlag::All, 4);
+    sizer.add(&threshold_slider, 0, SizerFlag::Expand | SizerFlag::All, 4);
+    sizer.add(&calibrate, 0, SizerFlag::All, 4);
+    sizer.add(&note, 0, SizerFlag::Expand | SizerFlag::All, 8);
+    sizer.add_sizer(&buttons, 0, SizerFlag::AlignRight, 0);
+    panel.set_sizer(sizer, true);
+    let dialog_sizer = BoxSizer::builder(Orientation::Vertical).build();
+    dialog_sizer.add(&panel, 1, SizerFlag::Expand, 0);
+    dialog.set_sizer(dialog_sizer, true);
+
+    {
+        browse.on_click(move |_| {
+            let picker = DirDialog::builder(
+                &dialog,
+                "Choose a folder of music for this source",
+                &folder_input.get_value(),
+            )
+            .with_style(DirDialogStyle::MustExist.bits())
+            .build();
+            if picker.show_modal() != ID_OK {
+                return;
+            }
+            let Some(path) = picker.get_path() else {
+                return;
+            };
+            let path = path.trim().to_string();
+            if path.is_empty() {
+                return;
+            }
+            folder_input.set_value(&path);
+            folder_input.set_focus();
+        });
+    }
+    // The calibration outlives the click that started it — five seconds of
+    // measurement answered from the pump — so it needs to know whether the
+    // dialog it would write to is still there. Same `alive` flag the credential
+    // validation in `preferences` uses, and for the same reason.
+    let alive = Rc::new(std::cell::Cell::new(true));
+    {
+        let app = app.clone();
+        let alive = alive.clone();
+        let announcer = threshold_announcer.clone();
+        calibrate.on_click(move |_| {
+            calibrate_duck(&app, threshold_slider, &announcer, calibrate, &alive);
+        });
+    }
+    {
+        ok.on_click(move |_| dialog.end_modal(ID_OK));
+    }
+    {
+        cancel.on_click(move |_| dialog.end_modal(ID_CANCEL));
+    }
+
+    let outcome = dialog.show_modal();
+    // Before anything is destroyed: a calibration still running would otherwise
+    // wake up on the next pump tick holding freed widgets.
+    alive.set(false);
+    if outcome == ID_OK {
+        set_source_kind(
+            app,
+            scene_index,
+            source_index,
+            SourceKindConfig::MediaPlayer(MediaPlayerSourceConfig {
+                folder: folder_input.get_value().trim().to_string(),
+                shuffle: shuffle.get_value(),
+                duck: duck.get_value(),
+                duck_percent: duck_slider.value().clamp(0, 100) as u32,
+                duck_threshold_db: mixer::clamp_threshold_db(threshold_slider.value()),
+            }),
+        );
+    }
+    // The UIA provider is keyed by HWND, so it has to go before the window does.
+    duck_announcer.uninstall();
+    threshold_announcer.uninstall();
+    dialog.destroy();
+}
+
+/// How long the user is asked to talk for. Long enough to say a sentence at a
+/// natural volume, short enough that nobody trails off before it ends.
+const CALIBRATION_SECONDS: f32 = 5.0;
+
+/// The longest the answer is waited for before the button is given back. The
+/// engine answers in `CALIBRATION_SECONDS`; this only covers it never answering
+/// at all, which would otherwise leave the button disabled for good.
+const CALIBRATION_PATIENCE: std::time::Duration = std::time::Duration::from_secs(20);
+
+/// Measures how loud the scene's other sources get while the user talks, and
+/// puts the threshold slider just under it.
+///
+/// The measurement is the engine's, not ours: it is the peak of the very
+/// [`mixer::trigger_level`] the ducker compares against, so what is calibrated
+/// is the thing being set. That also means it measures the active scene's
+/// microphones through their own faders and mutes — the same conditions the
+/// duck will happen under, and the reason a muted microphone reports silence
+/// rather than a number.
+fn calibrate_duck(
+    app: &Rc<App>,
+    slider: Slider,
+    announcer: &Rc<SliderAnnouncer>,
+    button: Button,
+    alive: &Rc<std::cell::Cell<bool>>,
+) {
+    // A result left parked by a run whose dialog was closed before it landed
+    // would otherwise be taken for this one's, instantly.
+    app.run.borrow_mut().duck_calibration = None;
+    app.engine
+        .send(crate::audio::EngineCommand::MeasureDuckTrigger {
+            seconds: CALIBRATION_SECONDS,
+        });
+    button.enable(false);
+    super::help::announce("Talk normally for five seconds, starting now.");
+
+    let deadline = std::time::Instant::now() + CALIBRATION_PATIENCE;
+    let app = app.clone();
+    let alive = alive.clone();
+    let announcer = announcer.clone();
+    super::run_when_ready(move || {
+        if !alive.get() {
+            return true;
+        }
+        let measured = app.run.borrow_mut().duck_calibration.take();
+        let Some(peak) = measured else {
+            if std::time::Instant::now() < deadline {
+                return false;
+            }
+            button.enable(true);
+            super::help::announce("The audio engine did not answer; nothing was changed.");
+            return true;
+        };
+        button.enable(true);
+        match mixer::calibrated_threshold_db(peak) {
+            Some(db) => {
+                slider.set_value(db);
+                // Set rather than announced: the sentence below is what the
+                // user hears, and two announcements at once would collide.
+                announcer.set_text("Start turning down at", &format!("{db} dB"));
+                super::help::announce(&format!(
+                    "Calibrated. The music will start turning down at {db} decibels."
+                ));
+            }
+            // Nothing was heard, which is a real answer and a common one: the
+            // microphone is muted, is in another scene, or is not there at all.
+            // Saying so beats writing a threshold that can never be crossed.
+            None => super::help::announce(
+                "Nothing loud enough to be a voice was heard, so the level was left alone. \
+                 Check that your microphone is in this scene, unmuted, and turned up.",
+            ),
+        }
+        true
+    });
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Adds a **Media Player** source type: a folder of the user's own music, played into the mixer as an ordinary source, that turns itself down while anybody is talking.

The motivation is the thing a streamer otherwise needs a second application and a loopback capture for — background music under a show — and doing it inside Pubsplash is what makes it accessible, duckable, and loop-safe by construction.

## What the user gets

- **A new source kind.** *Add source* → "Media Player" → pick a folder. Everything under it is played, subfolders included, so a whole music library works as well as one album. The folder is re-read every five minutes, so music added mid-session joins in without restarting anything.
- **Shuffle** (on by default) plays every file once before any of them repeats, reshuffles when it runs out, and never opens a new round with the track that just finished. Off plays the folder in filename order.
- **Ducking** (on by default): the music drops while any *other* source in the scene has signal and comes back about a second after it stops, so you can talk — or let chat be read aloud — over it without touching a fader. Other media players deliberately do not trigger it, so two of them never fight.
- **Two settings behind that**: *Turned-down level* (a percentage of the source's own fader, so 25% is a quarter of wherever the slider sits and 0% is silence) and *Start turning down at*, a −60…−10 dBFS threshold. Plus **Calibrate to my voice** — talk for five seconds and it sets the threshold from what it actually measured.
- **Transport**: Play/Pause, Next track and Open file, on the strip's volume-slider context menu (`SHIFT+F10` / Applications key / right click), all three bindable from a new **Media player** keybind category. *Open file* plays any single file from anywhere on disk, interrupts like a skip, and hands back to the folder afterwards; the first media player added is given `CTRL+O` for it. There is also an Open file button on the strip itself.
- Everything else is what any source has: fader, mute, monitor toggle, bus sends. The Scenes and Sources list reads back what is playing, or that it is paused / that the folder holds nothing playable.

## How it is built

Three new files, plus a ducker in the engine.

- **`src/media/mod.rs`** — the pure half: which extensions count (symphonia's coverage and nothing more — `.opus`, `.wma` and `.ape` are deliberately absent so a file can never be picked, announced, and then play as silence), the recursive scan with depth and file-count ceilings, and the `Playlist` shuffle policy.
- **`src/media/player.rs`** — one worker thread per player. It decodes **as it plays**, packet by packet, never holding a track in memory (five minutes of 48 kHz stereo f32 is 115 MB), resampling through a `StereoStream` that carries interpolation state across packet boundaries so there is no click forty times a second. It keeps only **a quarter second** queued ahead of the mixer on purpose: everything already in the ring *will* be heard, so a deeper buffer would put up to a second of latency on Pause and Next. Every wait is a `recv_timeout` on the command channel, so transport commands are acted on the moment they arrive.
- **`src/ui/media.rs`** — lifecycle, same shape and same reasons as `cue_feed`: workers keyed by `SourceConfig.name`, started and retired from `home::on_sources_changed` beside `sync_engine_sources`, and only for the **active** scene. Workers never touch `App` — they publish a `Status` and bump a generation counter the pump polls, like `tts::usage`.
- **`src/audio/mixer.rs`** — `Ducker`, with attack / hold / release rather than a plain gate, because the gaps between words fall below any usable threshold and a ducker without a hold pumps the music between syllables. Its gain is applied *after* the source's strip and *before* every tap — master, sends, and the local monitor — so **what the broadcaster monitors is exactly what listeners get, ducking included**.
- **`src/audio/mod.rs`** — `SourceSpec` grows `duck: Option<DuckSpec>` and `duck_trigger: bool`; the engine computes the trigger from every other source's post-fader block, so a muted or pulled-down microphone contributes the silence it is actually contributing. Duckers are carried across routing updates by source name when the settings still agree, so a scene edit mid-duck does not snap the music back to full. `EngineCommand::MeasureDuckTrigger` / `EngineEvent::DuckTriggerMeasured` are the calibration path — measuring **the engine's own trigger signal**, not a separate capture, since a threshold calibrated against a different signal than the one it is compared to is not calibrated at all.
- **`ExternalFeeds::queued`** is new: a feeder that could run forever needs to know how full the ring is, where a one-shot cue or utterance does not.
- **`Cargo.toml`**: symphonia goes from `features = ["mp3"]` to `["all"]` — the speech side only ever needed MP3, but a media player plays whatever is in the user's folder. Cargo.lock accordingly.

Config is `MediaPlayerSourceConfig` under `SourceKindConfig::MediaPlayer`, `#[serde(default)]`, with a `fix_up()` wired into `Config::fix_up_routing` that holds the duck percentage to 0–100 (above 100 it would boost rather than attenuate) and the threshold to the slider's range.

## Three fixes folded in, each with a note in the changelog

- **Next track did nothing.** A skip arriving during one of the worker's ring-drain waits was taken off the channel and then discarded. Play and pause were unaffected, which is why the transport looked like it worked.
- **Ducking stayed on while nobody was talking.** The trigger was the loudest single *sample* per 10 ms block, and a microphone's idle hiss has a crest factor around 10 dB — so an open mic in a silent room re-armed the hold every block and held the music down forever, looking from outside like ducking ignored the levels. It is now each block's RMS.
- **Ducking fired on a breath or a bump.** The threshold was fixed at −40 dB, close enough to a real room's floor that a fan or a knock on the desk ducked the music. Default is now −30 dB (deliberate speech), it is a user setting, and Calibrate exists.

Also changed: Next track now announces the name of the track it moved to rather than "next track", which the user already knew.

## Accessibility

Every new control follows the house rules: `set_accessible_name` on the sliders/checkboxes/text fields, `slider_uia::install` + `key_step` on both new sliders, `ok_button`/`dismiss_button` on the dialog so ENTER and ESCAPE both work, and the new context-menu items and the Open file button are Tab-reachable. `help.toml` gains entries for all six new controls plus the strip button, and the keybind specifier's label/message now cover media players. README documents the source type, the ducking settings, the transport and the monitoring caveat; `changelog.md` is updated under `## Unreleased`.

## Testing

`cargo test` — 635 pass. Two fail on my machine for reasons unrelated to this branch and present before it: `audio::device::tests::resolves_a_running_process_to_its_friendly_name` asserts the literal string "Windows Explorer" and this is a Spanish-localized Windows ("Explorador de Windows"), and `tts::sapi::tests::voice_enumeration_finds_installed_voices` finds no installed SAPI voice here.

New coverage includes `media::player::tests::{next_track_starts_the_next_track, pausing_stops_the_music, an_opened_file_plays_and_leaves_the_folder_where_it_was}` and the ducker's attack/hold/release, threshold and calibration behaviour in `audio::mixer::tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
