### PR TITLE
Configure Audiopub Icecast endpoints

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@
 
 ### Fixes
 
+- Audiopub services now use user-configured Icecast servers and ports.
+
+- Direct Icecast services now accept `/` as the mount point.
+
 ### Changes
 
 ## 0.1.6

--- a/src/config.rs
+++ b/src/config.rs
@@ -278,7 +278,8 @@ pub struct SiteConfig {
     pub email: String,
     /// Audiopub login password.
     pub password: Secret,
-    /// Raw Icecast server host or address, without the port.
+    /// Raw Icecast server host or address, without the port. Used by both
+    /// Audiopub and direct Icecast services.
     pub icecast_server: String,
     pub icecast_port: u16,
     /// Raw Icecast mount point, with or without a leading slash.
@@ -297,7 +298,7 @@ impl Default for SiteConfig {
             email: String::new(),
             password: Secret::default(),
             icecast_server: String::new(),
-            icecast_port: 8000,
+            icecast_port: 0,
             icecast_mount: String::new(),
             icecast_username: "source".to_string(),
             icecast_password: Secret::default(),
@@ -330,6 +331,7 @@ impl SiteConfig {
             id,
             nickname,
             service_type: StreamingServiceType::Icecast,
+            icecast_port: 8000,
             ..Default::default()
         }
     }
@@ -381,8 +383,15 @@ impl SiteConfig {
         if self.nickname.trim().is_empty() {
             self.nickname = self.display_name();
         }
-        if self.icecast_port == 0 {
+        if self.service_type == StreamingServiceType::Icecast && self.icecast_port == 0 {
             self.icecast_port = 8000;
+        } else if self.service_type == StreamingServiceType::Audiopub
+            && self.icecast_server.trim().is_empty()
+        {
+            // Audiopub profiles written before the server field was exposed
+            // inherited the old hidden 8000 default. Clear it so both endpoint
+            // values are explicitly entered together.
+            self.icecast_port = 0;
         }
     }
 }
@@ -1445,6 +1454,8 @@ mod tests {
         assert_eq!(service.nickname, "https://example.org/");
         assert_eq!(service.email, "dj@example.org");
         assert_eq!(service.password.as_str(), "secret");
+        assert_eq!(service.icecast_server, "");
+        assert_eq!(service.icecast_port, 0);
     }
 
     #[test]

--- a/src/net/icecast.rs
+++ b/src/net/icecast.rs
@@ -48,7 +48,7 @@ const CLOSE_TIMEOUT: Duration = Duration::from_secs(2);
 pub struct IcecastTarget {
     /// Host and port, e.g. `live.audiopub.site:8000`.
     pub host: String,
-    /// Mount without leading slash (the Audio Pub user id).
+    /// Mount without a leading slash, or `/` for the server root.
     pub mount: String,
     /// Source username, usually `source`.
     pub username: String,
@@ -257,8 +257,13 @@ impl IcecastConnection {
             target.username.trim()
         };
         let auth = authorization_header(username, target.password.as_str());
+        let mount_path = if target.mount == "/" {
+            "/".to_string()
+        } else {
+            format!("/{}", target.mount)
+        };
         let request = format!(
-            "PUT /{mount} HTTP/1.1\r\n\
+            "PUT {mount_path} HTTP/1.1\r\n\
              Host: {host}\r\n\
              Authorization: Basic {auth}\r\n\
              User-Agent: pubsplash/{version}\r\n\
@@ -266,7 +271,7 @@ impl IcecastConnection {
              Expect: 100-continue\r\n\
              Ice-Public: 0\r\n\
              \r\n",
-            mount = target.mount,
+            mount_path = mount_path,
             host = target.host,
             auth = auth,
             version = env!("CARGO_PKG_VERSION"),
@@ -386,6 +391,39 @@ mod tests {
         assert!(req.contains("Authorization: Basic c291cmNlOmtleQ=="));
         assert!(req.contains("Content-Type: audio/mpeg"));
         assert_eq!(audio, b"MP3!");
+    }
+
+    #[tokio::test]
+    async fn root_mount_uses_the_server_root_path() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 4096];
+            let n = sock.read(&mut buf).await.unwrap();
+            let req = String::from_utf8_lossy(&buf[..n]).to_string();
+            sock.write_all(b"HTTP/1.1 100 Continue\r\n\r\n")
+                .await
+                .unwrap();
+            req
+        });
+
+        let target = IcecastTarget {
+            host: addr.to_string(),
+            mount: "/".into(),
+            username: "source".into(),
+            password: Secret::new("key"),
+            content_type: "audio/mpeg".into(),
+        };
+        IcecastConnection::connect(&target)
+            .await
+            .unwrap()
+            .close()
+            .await;
+
+        let req = server.await.unwrap();
+        assert!(req.starts_with("PUT / HTTP/1.1\r\n"));
+        assert!(!req.starts_with("PUT //"));
     }
 
     #[tokio::test]

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -22,6 +22,8 @@ pub enum ServiceProfile {
         id: String,
         nickname: String,
         site_url: String,
+        server: String,
+        port: u16,
         email: String,
         password: Secret,
     },
@@ -195,7 +197,8 @@ enum Connection {
         /// the cookie store to outlive any one request.
         client: Arc<AudioPubClient>,
         identity: StreamIdentity,
-        site_url: String,
+        server: String,
+        port: u16,
     },
     Icecast {
         server: String,
@@ -237,34 +240,35 @@ impl ActiveStream {
     }
 }
 
-/// Derives the Icecast host from a site URL: Audiopub convention is the
-/// `live.` subdomain on port 8000 (matches audiopub.site's published
-/// connection details).
-fn icecast_host_for(site_url: &str) -> String {
-    let host = site_url
-        .trim_end_matches('/')
-        .rsplit("//")
-        .next()
-        .unwrap_or(site_url);
-    format!("live.{host}:8000")
-}
-
 fn normalize_mount(mount: &str) -> String {
-    mount.trim().trim_start_matches('/').to_string()
+    let mount = mount.trim();
+    if !mount.is_empty() && mount.chars().all(|c| c == '/') {
+        "/".to_string()
+    } else {
+        mount.trim_start_matches('/').to_string()
+    }
 }
 
 fn audiopub_target_for(
-    site_url: &str,
+    server: &str,
+    port: u16,
     identity: &StreamIdentity,
     content_type: &str,
-) -> IcecastTarget {
-    IcecastTarget {
-        host: icecast_host_for(site_url),
+) -> Result<IcecastTarget, String> {
+    let server = server.trim();
+    if server.is_empty() {
+        return Err("Enter the Audiopub Icecast server.".to_string());
+    }
+    if port == 0 {
+        return Err("Enter a valid Audiopub Icecast port.".to_string());
+    }
+    Ok(IcecastTarget {
+        host: format!("{server}:{port}"),
         mount: identity.user_id.clone(),
         username: "source".to_string(),
         password: identity.stream_key.clone(),
         content_type: content_type.to_string(),
-    }
+    })
 }
 
 fn direct_icecast_target(
@@ -347,6 +351,8 @@ async fn net_loop(mut commands: tokio_mpsc::UnboundedReceiver<NetCommand>, event
                         id,
                         nickname,
                         site_url,
+                        server,
+                        port,
                         email,
                         password,
                     } => {
@@ -366,7 +372,8 @@ async fn net_loop(mut commands: tokio_mpsc::UnboundedReceiver<NetCommand>, event
                                     connection = Some(Connection::Audiopub {
                                         client: Arc::new(client),
                                         identity,
-                                        site_url,
+                                        server,
+                                        port,
                                     });
                                     let _ = events.send(NetEvent::Connected {
                                         service_id: id,
@@ -1017,7 +1024,8 @@ async fn start_stream(
         Connection::Audiopub {
             client,
             identity,
-            site_url,
+            server,
+            port,
             ..
         } => {
             let stream_id = client
@@ -1025,7 +1033,7 @@ async fn start_stream(
                 .await
                 .map_err(|e| e.to_string())?;
 
-            let target = audiopub_target_for(site_url, identity, content_type);
+            let target = audiopub_target_for(server, *port, identity, content_type)?;
             // The first connect stays here, and inline, so a wrong stream key or
             // a banned account fails `Start streaming` at once with a reason.
             // Every *later* connect happens inside the sender task.
@@ -1366,25 +1374,14 @@ mod host_tests {
     use super::*;
 
     #[test]
-    fn icecast_host_derivation() {
-        assert_eq!(
-            super::icecast_host_for("https://audiopub.site/"),
-            "live.audiopub.site:8000"
-        );
-        assert_eq!(
-            super::icecast_host_for("http://example.org"),
-            "live.example.org:8000"
-        );
-    }
-
-    #[test]
-    fn audiopub_target_uses_site_identity() {
+    fn audiopub_target_uses_configured_server_and_site_identity() {
         let identity = StreamIdentity {
             user_id: "user-123".to_string(),
             stream_key: Secret::new("stream-key"),
         };
-        let target = audiopub_target_for("https://example.org/", &identity, "audio/mpeg");
-        assert_eq!(target.host, "live.example.org:8000");
+        let target =
+            audiopub_target_for("stream.example.org", 9000, &identity, "audio/mpeg").unwrap();
+        assert_eq!(target.host, "stream.example.org:9000");
         assert_eq!(target.mount, "user-123");
         assert_eq!(target.username, "source");
         assert_eq!(target.password.as_str(), "stream-key");
@@ -1419,5 +1416,18 @@ mod host_tests {
         };
         let target = direct_icecast_target(&conn, "audio/mpeg").unwrap();
         assert_eq!(target.username, "source");
+    }
+
+    #[test]
+    fn direct_icecast_target_accepts_the_root_mount() {
+        let conn = Connection::Icecast {
+            server: "radio.example.org".to_string(),
+            port: 8000,
+            mount: "/".to_string(),
+            username: "source".to_string(),
+            password: Secret::new("secret"),
+        };
+        let target = direct_icecast_target(&conn, "audio/mpeg").unwrap();
+        assert_eq!(target.mount, "/");
     }
 }

--- a/src/ui/connect_dialog.rs
+++ b/src/ui/connect_dialog.rs
@@ -166,14 +166,14 @@ pub fn show(app: &Rc<App>, frame: &Frame) {
     sizer.add(&service_type, 0, SizerFlag::Expand | SizerFlag::All, 4);
     sizer.add(&url_label, 0, SizerFlag::All, 4);
     sizer.add(&url_input, 0, SizerFlag::Expand | SizerFlag::All, 4);
-    sizer.add(&email_label, 0, SizerFlag::All, 4);
-    sizer.add(&email_input, 0, SizerFlag::Expand | SizerFlag::All, 4);
-    sizer.add(&password_label, 0, SizerFlag::All, 4);
-    sizer.add(&password_input, 0, SizerFlag::Expand | SizerFlag::All, 4);
     sizer.add(&server_label, 0, SizerFlag::All, 4);
     sizer.add(&server_input, 0, SizerFlag::Expand | SizerFlag::All, 4);
     sizer.add(&port_label, 0, SizerFlag::All, 4);
     sizer.add(&port_input, 0, SizerFlag::Expand | SizerFlag::All, 4);
+    sizer.add(&email_label, 0, SizerFlag::All, 4);
+    sizer.add(&email_input, 0, SizerFlag::Expand | SizerFlag::All, 4);
+    sizer.add(&password_label, 0, SizerFlag::All, 4);
+    sizer.add(&password_input, 0, SizerFlag::Expand | SizerFlag::All, 4);
     sizer.add(&mount_label, 0, SizerFlag::All, 4);
     sizer.add(&mount_input, 0, SizerFlag::Expand | SizerFlag::All, 4);
     sizer.add(&username_label, 0, SizerFlag::All, 4);
@@ -197,14 +197,24 @@ pub fn show(app: &Rc<App>, frame: &Frame) {
             let audiopub = service_type.get_selection() != 1;
             url_label.show(audiopub);
             url_input.show(audiopub);
+            server_label.set_label(if audiopub {
+                "Audiopub Icecast server"
+            } else {
+                "Icecast server"
+            });
+            port_label.set_label(if audiopub {
+                "Audiopub Icecast port"
+            } else {
+                "Icecast port"
+            });
             email_label.show(audiopub);
             email_input.show(audiopub);
             password_label.show(audiopub);
             password_input.show(audiopub);
-            server_label.show(!audiopub);
-            server_input.show(!audiopub);
-            port_label.show(!audiopub);
-            port_input.show(!audiopub);
+            server_label.show(true);
+            server_input.show(true);
+            port_label.show(true);
+            port_input.show(true);
             mount_label.show(!audiopub);
             mount_input.show(!audiopub);
             username_label.show(!audiopub);
@@ -303,7 +313,8 @@ pub fn show(app: &Rc<App>, frame: &Frame) {
                 email_input.set_value(&service.email);
                 password_input.set_value(service.password.as_str());
                 server_input.set_value(&service.icecast_server);
-                port_input.set_value(&service.icecast_port.to_string());
+                let port = (service.icecast_port != 0).then(|| service.icecast_port.to_string());
+                port_input.set_value(port.as_deref().unwrap_or_default());
                 mount_input.set_value(&service.icecast_mount);
                 username_input.set_value(&service.icecast_username);
                 icecast_password_input.set_value(service.icecast_password.as_str());

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1609,6 +1609,12 @@ pub fn service_profile_from_site(site: &SiteConfig) -> Result<ServiceProfile, St
     match site.service_type {
         StreamingServiceType::Audiopub => {
             let site_url = validate_site_url(&site.url)?;
+            if site.icecast_server.trim().is_empty() {
+                return Err("Enter the Audiopub Icecast server.".to_string());
+            }
+            if site.icecast_port == 0 {
+                return Err("Enter a valid Audiopub Icecast port.".to_string());
+            }
             if site.email.trim().is_empty() || site.password.is_empty() {
                 return Err("Enter your email and password first.".to_string());
             }
@@ -1616,6 +1622,8 @@ pub fn service_profile_from_site(site: &SiteConfig) -> Result<ServiceProfile, St
                 id: site.id.clone(),
                 nickname,
                 site_url,
+                server: site.icecast_server.trim().to_string(),
+                port: site.icecast_port,
                 email: site.email.trim().to_string(),
                 password: site.password.clone(),
             })
@@ -1627,7 +1635,7 @@ pub fn service_profile_from_site(site: &SiteConfig) -> Result<ServiceProfile, St
             if site.icecast_port == 0 {
                 return Err("Enter a valid Icecast port.".to_string());
             }
-            if site.icecast_mount.trim().trim_start_matches('/').is_empty() {
+            if site.icecast_mount.trim().is_empty() {
                 return Err("Enter the Icecast mount point.".to_string());
             }
             if site.icecast_password.is_empty() {


### PR DESCRIPTION
## Summary

- add explicit Audiopub Icecast server and port fields to streaming-service setup
- use the configured endpoint instead of deriving `live.<instance>:8000`
- permit `/` as a direct Icecast mount point for servers such as AzuraCast
- preserve compatibility with existing service configurations

## Why

Audiopub deployments do not share one Icecast hostname and port convention. Deriving the source endpoint from the instance URL prevents Pubsplash from connecting to deployments whose Icecast service uses another host or port. Direct Icecast validation also rejected the root mount, even though some compatible servers accept source connections there.

## User impact

Users can enter the Icecast endpoint supplied by their Audiopub operator, and direct Icecast users can stream to `/` without Pubsplash rewriting it to an empty or doubled path.

## Validation

- `cargo test --all-targets`
- focused coverage for configured Audiopub targets, backward-compatible profile loading, and root-mount request formatting

