### PR TITLE
Fix STAR voice discovery

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@
 
 ### Fixes
 
+- STAR voices now populate the voice dropdown from the configured coagulator.
+
+- STAR now defaults to the coagulator's standard port 7774.
+
 ### Changes
 
 ## 0.1.6

--- a/src/config.rs
+++ b/src/config.rs
@@ -956,7 +956,7 @@ pub struct SpeechConfig {
     pub google_api_key: Secret,
     /// Legacy fallback for sources without per-source provider settings.
     pub google_language_code: String,
-    /// WebSocket URL of a Star coagulator, e.g. `ws://localhost:4567`.
+    /// WebSocket URL of a Star coagulator, e.g. `ws://localhost:7774`.
     pub star_host: String,
     /// Longest message a network engine will synthesize. Chat can carry a wall
     /// of text, and the paid engines bill by the character, so messages are
@@ -988,7 +988,7 @@ impl Default for SpeechConfig {
             aws_engine: "neural".into(),
             google_api_key: Secret::default(),
             google_language_code: "en-US".into(),
-            star_host: "ws://localhost:4567".into(),
+            star_host: "ws://localhost:7774".into(),
             max_chars: Self::DEFAULT_MAX_CHARS,
             min_request_interval_ms: Self::DEFAULT_MIN_INTERVAL_MS,
             last_engine: String::new(),
@@ -999,6 +999,15 @@ impl Default for SpeechConfig {
 impl SpeechConfig {
     pub const DEFAULT_MAX_CHARS: usize = 500;
     pub const DEFAULT_MIN_INTERVAL_MS: u64 = 750;
+
+    fn fix_up(&mut self) {
+        // STAR has used 7774 since its first public implementation. Pubsplash
+        // previously supplied 4567 itself, so that exact old built-in value is
+        // safe to migrate while every user-entered endpoint remains untouched.
+        if self.star_host.trim() == "ws://localhost:4567" {
+            self.star_host = "ws://localhost:7774".into();
+        }
+    }
 
     /// The effective character cap; 0 in the file means "use the default".
     pub fn max_chars(&self) -> usize {
@@ -1049,6 +1058,7 @@ pub fn load_from(path: &Path) -> Config {
             config.scenes.ensure_default_scene();
             config.fix_up_routing();
             config.fix_up_tts_profiles();
+            config.speech.fix_up();
             config.keybinds.fix_up();
             config.mastodon.fix_up();
             config
@@ -1114,6 +1124,28 @@ mod tests {
         save_to(&config, &path);
         assert_eq!(load_from(&path).audio.master_volume, 7);
         assert!(!temp.exists(), "temp file should be renamed away, not left");
+    }
+
+    #[test]
+    fn the_old_builtin_star_port_is_migrated_without_touching_custom_hosts() {
+        let old_path = temp_path("old_star_port.json");
+        std::fs::write(
+            &old_path,
+            r#"{"speech":{"star_host":"ws://localhost:4567"}}"#,
+        )
+        .unwrap();
+        assert_eq!(load_from(&old_path).speech.star_host, "ws://localhost:7774");
+
+        let custom_path = temp_path("custom_star_port.json");
+        std::fs::write(
+            &custom_path,
+            r#"{"speech":{"star_host":"ws://localhost:4568"}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            load_from(&custom_path).speech.star_host,
+            "ws://localhost:4568"
+        );
     }
 
     #[test]

--- a/src/tts/catalog.rs
+++ b/src/tts/catalog.rs
@@ -174,6 +174,7 @@ impl TtsCatalog {
                     | super::engines::ELEVENLABS
                     | super::engines::GOOGLE
                     | super::engines::OPENAI
+                    | super::engines::STAR
             )
         });
     }
@@ -368,7 +369,7 @@ pub fn discover(engine: &str, speech: &SpeechConfig) -> Result<EngineCatalog, Tt
         ),
         engines::OPENAI => engines::openai::discover(speech)?,
         engines::ELEVENLABS => engines::elevenlabs::discover(speech)?,
-        engines::AZURE | engines::GOOGLE => EngineCatalog::from_voices(
+        engines::AZURE | engines::GOOGLE | engines::STAR => EngineCatalog::from_voices(
             Vec::new(),
             engines::build(engine, speech)
                 .expect("engine is registered")
@@ -388,6 +389,9 @@ pub fn discover(engine: &str, speech: &SpeechConfig) -> Result<EngineCatalog, Tt
 pub fn startup_engines(speech: &SpeechConfig) -> Vec<&'static str> {
     use super::engines;
     let mut selected = vec![engines::SAPI, engines::EDGE];
+    if !speech.star_host.trim().is_empty() {
+        selected.push(engines::STAR);
+    }
     if !speech.openai_api_key.as_str().trim().is_empty() {
         selected.push(engines::OPENAI);
     }
@@ -612,12 +616,26 @@ mod tests {
     fn startup_refresh_requires_complete_credentials() {
         let mut speech = SpeechConfig {
             aws_access_key_id: "id".into(),
+            star_host: String::new(),
             ..Default::default()
         };
         assert!(!startup_engines(&speech).contains(&super::super::engines::AWS));
         speech.aws_secret_access_key = crate::secret::Secret::new("secret");
         assert!(startup_engines(&speech).contains(&super::super::engines::AWS));
         assert!(!startup_engines(&speech).contains(&super::super::engines::STAR));
+        speech.star_host = "ws://localhost:7774".into();
+        assert!(startup_engines(&speech).contains(&super::super::engines::STAR));
         assert!(!startup_engines(&speech).contains(&super::super::engines::GTTS));
+    }
+
+    #[test]
+    fn star_voices_survive_catalog_normalization() {
+        let mut catalog = TtsCatalog::default();
+        catalog.engines.insert(
+            super::super::engines::STAR.into(),
+            EngineCatalog::from_voices(Vec::new(), vec![Voice::plain("Microsoft Sam")]),
+        );
+        catalog.normalize();
+        assert_eq!(catalog.engines[super::super::engines::STAR].voices.len(), 1);
     }
 }

--- a/src/tts/engines/star.rs
+++ b/src/tts/engines/star.rs
@@ -108,20 +108,11 @@ impl SpeechEngine for Star {
         let payload = serde_json::json!({ "user": USER }).to_string();
         let message = block_on(self.exchange(payload))?;
         let Message::Text(text) = message else {
-            return Ok(Vec::new());
+            return Err(TtsError::Network(
+                "the server returned an unexpected voice-list reply".into(),
+            ));
         };
-        let body: serde_json::Value =
-            serde_json::from_str(&text).map_err(|e| TtsError::Other(e.to_string()))?;
-        Ok(body
-            .get("voices")
-            .and_then(|v| v.as_array())
-            .map(|list| {
-                list.iter()
-                    .filter_map(|v| v.as_str())
-                    .map(Voice::plain)
-                    .collect()
-            })
-            .unwrap_or_default())
+        parse_voices(&text)
     }
 
     // No `usage_model`: Star is self-hosted and has neither models nor billing.
@@ -130,6 +121,28 @@ impl SpeechEngine for Star {
         // Empty means the server's own default, which it never names back.
         (!request.voice.is_empty()).then(|| request.voice.clone())
     }
+}
+
+/// Parses the coagulator's response to `{"user": 4}`.
+fn parse_voices(text: &str) -> Result<Vec<Voice>, TtsError> {
+    let body: serde_json::Value =
+        serde_json::from_str(text).map_err(|e| TtsError::Other(e.to_string()))?;
+    if let Some(detail) = body.get("error").and_then(|value| value.as_str()) {
+        return Err(TtsError::Service {
+            service: SERVICE,
+            status: 0,
+            detail: detail.to_string(),
+        });
+    }
+    let list = body
+        .get("voices")
+        .and_then(|value| value.as_array())
+        .ok_or_else(|| TtsError::Other("Star returned no voice list".into()))?;
+    Ok(list
+        .iter()
+        .filter_map(|value| value.as_str())
+        .map(Voice::plain)
+        .collect())
 }
 
 /// Splits a reply frame into its declared file extension and the audio bytes.
@@ -204,5 +217,20 @@ mod tests {
             engine.voices().unwrap_err(),
             TtsError::NotConfigured(_)
         ));
+    }
+
+    #[test]
+    fn the_upstream_voice_list_shape_is_parsed() {
+        let voices = parse_voices(r#"{"voices":["Microsoft Sam","Alex"]}"#).unwrap();
+        assert_eq!(voices.len(), 2);
+        assert_eq!(voices[0].id, "Microsoft Sam");
+        assert_eq!(voices[1].label, "Alex");
+    }
+
+    #[test]
+    fn a_protocol_error_is_not_mistaken_for_an_empty_voice_list() {
+        let error = parse_voices(r#"{"error":"must be revision 5 or higher"}"#).unwrap_err();
+        assert!(error.to_string().contains("revision 5"));
+        assert!(parse_voices("{}").is_err());
     }
 }

--- a/src/ui/preferences.rs
+++ b/src/ui/preferences.rs
@@ -602,6 +602,10 @@ fn build_engine_page(
                 "dialog.preferences.speech.starHost",
                 "Star server URL",
             );
+            let draft_host = host;
+            validation_button(app, page, sizer, engines::STAR, alive, move |speech| {
+                speech.star_host = draft_host.get_value().trim().to_string();
+            });
         }
         // SAPI, Microsoft Edge and Google Translate. Nothing focusable here, so
         // the tab order runs straight from the picker to the limits below —
@@ -625,11 +629,11 @@ fn validation_button(
     apply_draft: impl Fn(&mut crate::config::SpeechConfig) + 'static,
 ) {
     let button = Button::builder(page).with_label("&Validate").build();
-    super::set_accessible_name(&button, "Validate credentials");
+    super::set_accessible_name(&button, "Validate settings");
     let status = StaticText::builder(page)
-        .with_label("Credentials not yet validated.")
+        .with_label("Settings not yet validated.")
         .build();
-    super::set_accessible_name(&status, "Credential validation status: not yet validated");
+    super::set_accessible_name(&status, "Settings validation status: not yet validated");
     sizer.add(&button, 0, SizerFlag::All, 4);
     sizer.add(&status, 0, SizerFlag::All, 4);
     let apply_draft = Rc::new(apply_draft);
@@ -643,12 +647,9 @@ fn validation_button(
             apply_draft(&mut draft);
             button_for_click.enable(false);
             button_for_click.set_label("Validating…");
-            super::set_accessible_name(&button_for_click, "Validating credentials");
-            status_for_click.set_label("Validating credentials…");
-            super::set_accessible_name(
-                &status_for_click,
-                "Credential validation status: validating",
-            );
+            super::set_accessible_name(&button_for_click, "Validating settings");
+            status_for_click.set_label("Validating settings…");
+            super::set_accessible_name(&status_for_click, "Settings validation status: validating");
             let (sender, receiver) = crossbeam_channel::bounded(1);
             std::thread::Builder::new()
                 .name(format!("tts-validate-{engine}"))
@@ -672,7 +673,7 @@ fn validation_button(
                 };
                 button.enable(true);
                 button.set_label("&Validate");
-                super::set_accessible_name(&button, "Validate credentials");
+                super::set_accessible_name(&button, "Validate settings");
                 match result {
                     Ok((draft, catalog)) => {
                         commit_validated_credentials(
@@ -683,17 +684,17 @@ fn validation_button(
                         crate::tts::catalog::commit_engine(engine, catalog);
                         app.save_config();
                         app.flush_config();
-                        status.set_label("Credentials validated and saved.");
+                        status.set_label("Settings validated and saved.");
                         super::set_accessible_name(
                             &status,
-                            "Credential validation succeeded; credentials saved",
+                            "Settings validation succeeded; settings saved",
                         );
                     }
                     Err(error) => {
                         status.set_label(&format!("Validation failed: {error}"));
                         super::set_accessible_name(
                             &status,
-                            &format!("Credential validation failed: {error}"),
+                            &format!("Settings validation failed: {error}"),
                         );
                     }
                 }
@@ -722,6 +723,7 @@ fn commit_validated_credentials(
             saved.aws_region = draft.aws_region.clone();
         }
         engines::GOOGLE => saved.google_api_key = draft.google_api_key.clone(),
+        engines::STAR => saved.star_host = draft.star_host.clone(),
         _ => {}
     }
 }
@@ -751,7 +753,7 @@ fn text_row(
     speech_row(app, panel, sizer, label, engine, false, read, write)
 }
 
-/// Builds one setting row and wires it to save as the user types.
+/// Builds one setting row.
 ///
 /// The caller tags the returned control for context help, because `gen-help`
 /// needs those arguments to be literals at the call site.
@@ -761,10 +763,10 @@ fn speech_row(
     panel: &Panel,
     sizer: &BoxSizer,
     label: &str,
-    engine: &'static str,
+    _engine: &'static str,
     secret: bool,
     read: fn(&crate::config::SpeechConfig) -> String,
-    write: fn(&mut crate::config::SpeechConfig, String),
+    _write: fn(&mut crate::config::SpeechConfig, String),
 ) -> TextCtrl {
     let caption = StaticText::builder(panel).with_label(label).build();
     let mut builder = TextCtrl::builder(panel).with_value(&read(&app.config.borrow().speech));
@@ -776,20 +778,6 @@ fn speech_row(
     super::set_accessible_name(&input, label);
     sizer.add(&caption, 0, SizerFlag::All, 2);
     sizer.add(&input, 0, SizerFlag::Expand | SizerFlag::All, 2);
-    // Star has no enumerable catalog and therefore no Validate button. Its URL
-    // remains an ordinary setting; credential-bearing providers stay local to
-    // their widgets until validation succeeds.
-    if engine == crate::tts::engines::STAR {
-        let app = app.clone();
-        let input_for_update = input;
-        input.clone().on_text_updated(move |_| {
-            write(
-                &mut app.config.borrow_mut().speech,
-                input_for_update.get_value().trim().to_string(),
-            );
-            app.save_config();
-        });
-    }
     input
 }
 
@@ -1354,13 +1342,20 @@ mod speech_validation_tests {
     fn validation_commits_only_the_selected_provider() {
         let mut saved = crate::config::SpeechConfig {
             google_api_key: Secret::new("old-google"),
+            star_host: "ws://old.example:7774".into(),
             ..Default::default()
         };
         let mut draft = saved.clone();
         draft.openai_api_key = Secret::new("new-openai");
         draft.google_api_key = Secret::new("draft-google");
+        draft.star_host = "ws://new.example:7774".into();
         commit_validated_credentials(crate::tts::engines::OPENAI, &mut saved, &draft);
         assert_eq!(saved.openai_api_key.as_str(), "new-openai");
+        assert_eq!(saved.google_api_key.as_str(), "old-google");
+        assert_eq!(saved.star_host, "ws://old.example:7774");
+
+        commit_validated_credentials(crate::tts::engines::STAR, &mut saved, &draft);
+        assert_eq!(saved.star_host, "ws://new.example:7774");
         assert_eq!(saved.google_api_key.as_str(), "old-google");
     }
 }


### PR DESCRIPTION
## Summary

- discover STAR voices from the configured coagulator and retain them in the TTS catalog
- refresh STAR during startup when it is configured
- validate and save STAR settings through the same accessible workflow as other network engines
- use STAR's standard coagulator port 7774 and migrate the previous built-in localhost default
- report malformed or protocol-error voice-list replies instead of treating them as an empty list

## Why

Pubsplash could request STAR's voice list, but catalog normalization discarded the result and startup discovery did not include STAR. Consequently the source dialog exposed no STAR voices. The previous default port also did not match STAR's implementation.

## User impact

After validating a STAR coagulator, its voices populate the source-dialog dropdown and remain available through normal catalog refreshes. Existing users of the old built-in localhost default migrate to port 7774, while custom endpoints are left unchanged.

## Validation

- `cargo test --all-targets`
- focused coverage for STAR response parsing, catalog normalization, startup selection, settings validation, and default-port migration

